### PR TITLE
Fixed light header when used with overlap & sticky

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -267,7 +267,7 @@
 		path {
 			fill: $color__navigation-link;
 
-			.overlap-light & {
+			.overlap-light .site-header:not(.stuck) & {
 				fill: #fff;
 			}
 		}


### PR DESCRIPTION
This fixes the color of the menu icon when using a sticky header plus the Header Overlap: Enabled - Light Text page settings. Without this fix the icon is white on a white background.

Before - http://g.recordit.co/mEIbMKviPL.gif

After - http://g.recordit.co/xRx3gmXLKN.gif