### PR TITLE
Fixed theme reference on about page

### DIFF
--- a/admin/about/page-woocommerce.php
+++ b/admin/about/page-woocommerce.php
@@ -1,6 +1,6 @@
-<h3><?php _e( 'WooCommerce Integration', 'siteorigin-unwind' ) ?></h3>
+<h3><?php _e( 'WooCommerce Integration', 'siteorigin-corp' ) ?></h3>
 <img src="<?php echo get_template_directory_uri() ?>/admin/about/woocommerce.png" class="about-image-right about-image-no-text-below" />
 <p>
-	<?php _e( "Corp is a full-featured WooCommerce theme.", 'siteorigin-unwind' ) ?>
-	<?php _e( "Use it to build your full online store with a stunning design and features like quick-view.", 'siteorigin-unwind' ) ?>
+	<?php _e( "Corp is a full-featured WooCommerce theme.", 'siteorigin-corp' ) ?>
+	<?php _e( "Use it to build your full online store with a stunning design.", 'siteorigin-corp' ) ?>
 </p>

--- a/admin/about/page-woocommerce.php
+++ b/admin/about/page-woocommerce.php
@@ -1,6 +1,6 @@
 <h3><?php _e( 'WooCommerce Integration', 'siteorigin-unwind' ) ?></h3>
 <img src="<?php echo get_template_directory_uri() ?>/admin/about/woocommerce.png" class="about-image-right about-image-no-text-below" />
 <p>
-	<?php _e( "Unwind is a full-featured WooCommerce theme.", 'siteorigin-unwind' ) ?>
+	<?php _e( "Corp is a full-featured WooCommerce theme.", 'siteorigin-unwind' ) ?>
 	<?php _e( "Use it to build your full online store with a stunning design and features like quick-view.", 'siteorigin-unwind' ) ?>
 </p>


### PR DESCRIPTION
This fixes Unwind being referenced in the themes about page. This also updates the text domain to siteorigin-corp and removes "and features like quick-view" since this is not yet a feature of Corp. 