### PR TITLE
Change Search Form URL

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -1,4 +1,4 @@
-<form method="get" class="search-form" action="<?php echo esc_url( site_url() ) ?>">
+<form method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ) ?>">
 	<label for='s' class='screen-reader-text'><?php esc_html_e( 'Search for:', 'siteorigin-corp' ); ?></label>
 	<input type="search" name="s" placeholder="<?php esc_attr_e( 'Search', 'siteorigin-corp') ?>" value="<?php echo get_search_query() ?>" />
 	<button type="submit">


### PR DESCRIPTION
We shouldn't be using site_url() for the search form as the WordPress address is the WordPress location files URL, and not the actual site URL. As a result, it can be different to the actual Site Address so this can cause a 404 upon searching if the WordPress URL is different to the Site Address.

![](https://i.imgur.com/YV4CMPp.png)