### PR TITLE
Mobile Menu: If mobile menu is disabled, no menu will appear on mobile

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1356,11 +1356,6 @@ add_filter( 'siteorigin_settings_custom_css', 'siteorigin_corp_wc_settings_custo
  * Add CSS for mobile menu breakpoint.
  */
 function siteorigin_corp_menu_breakpoint_css( $css, $settings ) {
-	$breakpoint = siteorigin_setting( 'navigation_mobile_menu_collapse' );
-	if( empty( $breakpoint ) ) {
-		$breakpoint = 768;
-	}
-
 	// Ensure mobile menu is enabled before outputting any CSS.
 	$navigation_mobile_menu = siteorigin_setting( 'navigation_mobile_menu' );
 	if( empty( $navigation_mobile_menu ) ){
@@ -1368,7 +1363,7 @@ function siteorigin_corp_menu_breakpoint_css( $css, $settings ) {
 	}
 	
 	if ( is_rtl() ) {
-		$css .= '@media (max-width: ' . intval( $breakpoint ) . 'px) {
+		$css .= '@media (max-width: ' . intval( siteorigin_setting( 'navigation_mobile_menu_collapse' ) ) . 'px) {
 			#masthead .search-toggle {
 				margin-right: 0;
 				margin-left: 20px;
@@ -1386,13 +1381,13 @@ function siteorigin_corp_menu_breakpoint_css( $css, $settings ) {
 				display: none;
 			}
 		}
-		@media (min-width: ' . ( 1 + intval( $breakpoint ) ) . 'px) {
+		@media (min-width: ' . ( 1 + intval( siteorigin_setting( 'navigation_mobile_menu_collapse' ) ) ) . 'px) {
 			#masthead #mobile-navigation {
 				display: none !important;
 			}
 		}';		
 	} else {
-		$css .= '@media (max-width: ' . intval( $breakpoint ) . 'px) {
+		$css .= '@media (max-width: ' . intval( siteorigin_setting( 'navigation_mobile_menu_collapse' ) ) . 'px) {
 			#masthead .search-toggle {
 				margin-right: 20px;
 			}
@@ -1409,7 +1404,7 @@ function siteorigin_corp_menu_breakpoint_css( $css, $settings ) {
 				display: none;
 			}
 		}
-		@media (min-width: ' . ( 1 + intval( $breakpoint ) ) . 'px) {
+		@media (min-width: ' . ( 1 + intval( siteorigin_setting( 'navigation_mobile_menu_collapse' ) ) ) . 'px) {
 			#masthead #mobile-navigation {
 				display: none !important;
 			}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1356,10 +1356,14 @@ add_filter( 'siteorigin_settings_custom_css', 'siteorigin_corp_wc_settings_custo
  * Add CSS for mobile menu breakpoint.
  */
 function siteorigin_corp_menu_breakpoint_css( $css, $settings ) {
-	$breakpoint = ! empty( siteorigin_setting( 'navigation_mobile_menu_collapse' ) ) ? siteorigin_setting( 'navigation_mobile_menu_collapse' ) : 768;
+	$breakpoint = siteorigin_setting( 'navigation_mobile_menu_collapse' );
+	if( empty( $breakpoint ) ) {
+		$breakpoint = 768;
+	}
 
 	// Ensure mobile menu is enabled before outputting any CSS.
-	if( empty( siteorigin_setting( 'navigation_mobile_menu') ) ){
+	$navigation_mobile_menu = siteorigin_setting( 'navigation_mobile_menu' );
+	if( empty( $navigation_mobile_menu ) ){
 		return;	
 	}
 	

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1356,10 +1356,10 @@ add_filter( 'siteorigin_settings_custom_css', 'siteorigin_corp_wc_settings_custo
  * Add CSS for mobile menu breakpoint.
  */
 function siteorigin_corp_menu_breakpoint_css( $css, $settings ) {
-	$breakpoint = isset( $settings[ 'theme_settings_navigation_mobile_menu_collapse' ] ) ? $settings[ 'theme_settings_navigation_mobile_menu_collapse' ] : 768;
+	$breakpoint = ! empty( siteorigin_setting( 'navigation_mobile_menu_collapse' ) ) ? siteorigin_setting( 'navigation_mobile_menu_collapse' ) : 768;
 
 	// Ensure mobile menu is enabled before outputting any CSS.
-	if( empty( $settings['theme_settings_navigation_mobile_menu'] ) ){
+	if( empty( siteorigin_setting( 'navigation_mobile_menu') ) ){
 		return;	
 	}
 	

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1358,6 +1358,11 @@ add_filter( 'siteorigin_settings_custom_css', 'siteorigin_corp_wc_settings_custo
 function siteorigin_corp_menu_breakpoint_css( $css, $settings ) {
 	$breakpoint = isset( $settings[ 'theme_settings_navigation_mobile_menu_collapse' ] ) ? $settings[ 'theme_settings_navigation_mobile_menu_collapse' ] : 768;
 
+	// Ensure mobile menu is enabled before outputting any CSS.
+	if( empty( $settings['theme_settings_navigation_mobile_menu'] ) ){
+		return;	
+	}
+	
 	if ( is_rtl() ) {
 		$css .= '@media (max-width: ' . intval( $breakpoint ) . 'px) {
 			#masthead .search-toggle {


### PR DESCRIPTION
Currently, the standard menu is always set to hide on mobile regardless of whether or not the mobile menu is enabled or not. This PR changes that.