### PR TITLE
Fix Max Mega Menu Mobile Menu placement on mobile

### DIFF
--- a/sass/site/_header.scss
+++ b/sass/site/_header.scss
@@ -49,17 +49,19 @@
     }
 
 	.site-header-inner {
-		-ms-flex-align: center;
-		-webkit-align-items: center;
-		-webkit-box-align: center;
-	    align-items: center;
-		display: -ms-flexbox;
-		display: -webkit-flex;
-		display: flex;
-		-webkit-justify-content: space-between;
-		justify-content: space-between;
 		width: 100%;
-	}	
+	    @media (min-width: 600px) {
+			-ms-flex-align: center;
+			-webkit-align-items: center;
+			-webkit-box-align: center;
+			align-items: center;
+			display: -ms-flexbox;
+			display: -webkit-flex;
+			display: flex;
+			-webkit-justify-content: space-between;
+			justify-content: space-between;
+		}
+	}
 	
 	.site-branding {
 		padding-right: 20px;

--- a/style.css
+++ b/style.css
@@ -1486,16 +1486,18 @@ a {
   .site-header.stuck {
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075); }
   .site-header .site-header-inner {
-    -ms-flex-align: center;
-    -webkit-align-items: center;
-    -webkit-box-align: center;
-    align-items: center;
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-justify-content: space-between;
-    justify-content: space-between;
     width: 100%; }
+    @media (min-width: 600px) {
+      .site-header .site-header-inner {
+        -ms-flex-align: center;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        align-items: center;
+        display: -ms-flexbox;
+        display: -webkit-flex;
+        display: flex;
+        -webkit-justify-content: space-between;
+        justify-content: space-between; } }
   .site-header .site-branding {
     padding-right: 20px; }
     .site-header .site-branding .site-title {


### PR DESCRIPTION
On mobile, the Max Mega Menu Mobile Menu isn't displaying correctly due to .site-header-inner having flex applied to it. This PR removes flex from .site-header-inner on mobile and it allows the masthead to collapse correctly when using Max Mega Menu.

![](https://i.imgur.com/RdZv7Qp.png)

[Video of issue](https://drive.google.com/a/siteorigin.com/uc?id=1CSwltnXq97jC5xj0mDXtZbP4qfZK9LUT)