### PR TITLE
Avoid always showing mobile menu scroll bar in FF and IE

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -283,7 +283,7 @@
 	background: $color__navigation-drop-down-background;
 	left: 0;
 	overflow-x: hidden;
-	overflow-y: scroll;
+	overflow-y: auto;
 	position: absolute;
 	top: 101%;
 	-webkit-overflow-scrolling: touch;

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -282,17 +282,25 @@
 #mobile-navigation {
 	background: $color__navigation-drop-down-background;
 	left: 0;
-	overflow-x: hidden;
-	overflow-y: auto;
+	overflow-y: scroll;
 	position: absolute;
 	top: 101%;
 	-webkit-overflow-scrolling: touch;
 	width: 100%;
 	z-index: 10;
-
+	
 	&::-webkit-scrollbar {
-		display: none;
+		width: 4px;
 	}
+
+	&::-webkit-scrollbar-track {
+		-webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, .3);
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background-color: darkgrey;
+		outline: 1px solid slategrey;
+	}	
 
 	ul {
 		list-style: none;

--- a/style.css
+++ b/style.css
@@ -704,15 +704,19 @@ a {
 #mobile-navigation {
   background: #262627;
   left: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: scroll;
   position: absolute;
   top: 101%;
   -webkit-overflow-scrolling: touch;
   width: 100%;
   z-index: 10; }
   #mobile-navigation::-webkit-scrollbar {
-    display: none; }
+    width: 4px; }
+  #mobile-navigation::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3); }
+  #mobile-navigation::-webkit-scrollbar-thumb {
+    background-color: darkgrey;
+    outline: 1px solid slategrey; }
   #mobile-navigation ul {
     list-style: none;
     margin: 0;

--- a/style.css
+++ b/style.css
@@ -705,7 +705,7 @@ a {
   background: #262627;
   left: 0;
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
   position: absolute;
   top: 101%;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Ref #52. The issue doesn’t seem to persist in Safari regardless of the scroll value. I see the issue in FF and I guess it’s there in IE.