### PR TITLE
Prevent issue where submenu bottom border would sometimes disappear

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -65,7 +65,7 @@
 
 				&:last-of-type {
 
-					a {
+					> a {
 						border-bottom: none;
 					}
 				}

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: SiteOrigin
 Author URI: https://siteorigin.com/
 Theme URI: https://siteorigin.com/theme/corp/
 Description: A modern business theme from SiteOrigin. Corp is versatile and quick to customize. Fast loading and fully loaded with all the modern theme features you've come to expect and enjoy. Convert visitors to customers with effective layouts and beautifuly presented landing pages. Corp offers seamless integration with Page Builder by SiteOrigin, a custom WooCommerce design and five unique blog layouts. A stunning portfolio layout to follow soon.
-Version: dev
+Version: 1.2.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: siteorigin-corp
@@ -572,8 +572,8 @@ a {
         .main-navigation ul .sub-menu li:first-of-type,
         .main-navigation ul .children li:first-of-type {
           border-top: 2px solid #f14e4e; }
-        .main-navigation ul .sub-menu li:last-of-type a,
-        .main-navigation ul .children li:last-of-type a {
+        .main-navigation ul .sub-menu li:last-of-type > a,
+        .main-navigation ul .children li:last-of-type > a {
           border-bottom: none; }
     .main-navigation ul li:hover > ul,
     .main-navigation ul li.focus > ul {
@@ -2834,5 +2834,3 @@ object {
             font-size: 26px; } }
         .featured-posts-slider .slides .slide .slide-content .entry-title a {
           color: #fff; }
-
-/*# sourceMappingURL=sass/maps/style.css.map */

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Author: SiteOrigin
 Author URI: https://siteorigin.com/
 Theme URI: https://siteorigin.com/theme/corp/
 Description: A modern business theme from SiteOrigin. Corp is versatile and quick to customize. Fast loading and fully loaded with all the modern theme features you've come to expect and enjoy. Convert visitors to customers with effective layouts and beautifuly presented landing pages. Corp offers seamless integration with Page Builder by SiteOrigin, a custom WooCommerce design and five unique blog layouts. A stunning portfolio layout to follow soon.
-Version: 1.2.3
+Version: dev
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: siteorigin-corp
@@ -2834,3 +2834,5 @@ object {
             font-size: 26px; } }
         .featured-posts-slider .slides .slide .slide-content .entry-title a {
           color: #fff; }
+ 
+  /*# sourceMappingURL=sass/maps/style.css.map */


### PR DESCRIPTION
This PR will ensure the CSS used to remove the border from the last menu-item only affects the direct descendant rather than all descendent that are anchors.

![](https://vgy.me/GV6Oii.png)

Note: I find this quite tricky to replicate. The easiest way I found is to create four submenus with more than 4 menu items each.