### PR TITLE
Allow mobile users to open sub menu when mobile menu is disabled

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -29,7 +29,6 @@ function siteorigin_corp_body_classes( $classes ) {
 	// Mobile compatibility classes.
 	$classes[] = 'css3-animations';
 	$classes[] = 'no-js';
-	$classes[] = 'no-touch';
 
 	// Non-singlar pages.
 	if ( ! is_singular() ) {

--- a/js/jquery.theme.js
+++ b/js/jquery.theme.js
@@ -328,11 +328,8 @@ jQuery( function( $ ) {
 		$( 'html, body' ).animate( { scrollTop: 0 } );
 	} );
 
-	// This this is a touch device. We detect this through ontouchstart, msMaxTouchPoints and MaxTouchPoints.
+	// Detect if is a touch device. We detect this through ontouchstart, msMaxTouchPoints and MaxTouchPoints.
 	if ( 'ontouchstart' in document.documentElement || window.navigator.msMaxTouchPoints || window.navigator.MaxTouchPoints ) {
-		$('body').removeClass('no-touch');
-	}
-	if ( !$( 'body' ).hasClass( 'no-touch' ) ) {
 		if ( /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream ) {
 			$( 'body' ).css( 'cursor', 'pointer' );
 		}

--- a/js/jquery.theme.js
+++ b/js/jquery.theme.js
@@ -328,14 +328,29 @@ jQuery( function( $ ) {
 		$( 'html, body' ).animate( { scrollTop: 0 } );
 	} );
 
-	// Detect if is a touch device. We detect this through ontouchstart, msMaxTouchPoints and MaxTouchPoints.
+	// This this is a touch device. We detect this through ontouchstart, msMaxTouchPoints and MaxTouchPoints.
 	if ( 'ontouchstart' in document.documentElement || window.navigator.msMaxTouchPoints || window.navigator.MaxTouchPoints ) {
 		if ( /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream ) {
 			$( 'body' ).css( 'cursor', 'pointer' );
 		}
 		$( '.main-navigation #primary-menu').find('.menu-item-has-children > a' ).each( function() {
 			$( this ).click( function( e ) {
-				e.preventDefault();
+				var link = $( this );
+				e.stopPropagation();
+
+ 				if ( ! link.hasClass( 'hover' ) ) {
+					e.preventDefault();	
+ 					// Remove .hover from all other sub menus
+ 					$( '.hover' ).removeClass( 'hover' );
+
+					link.addClass( 'hover' );
+
+					// Remove .hover class when user clicks outside of sub menu
+	 				$( document ).click( function() {
+						link.removeClass( 'hover' );
+						link.unbind( 'click' );	
+					} );
+				}
 			} );
 		} );
 	}

--- a/js/jquery.theme.js
+++ b/js/jquery.theme.js
@@ -335,25 +335,7 @@ jQuery( function( $ ) {
 		}
 		$( '.main-navigation #primary-menu').find('.menu-item-has-children > a' ).each( function() {
 			$( this ).click( function( e ) {
-				var link = $( this );
-				e.stopPropagation();
-				link.parent().addClass( 'touch-drop' );
-
-				if ( link.hasClass( 'hover' ) ) {
-					link.unbind( 'click' );
-				} else {
-					link.addClass( 'hover' );
-					e.preventDefault();
-				}
-
-				$( '.main-navigation #primary-menu > .menu-item-has-children:not(.touch-drop) > a' ).click( function() {
-					link.removeClass('hover').parent().removeClass('touch-drop');
-				} );
-
-				$( document ).click( function() {
-					link.removeClass( 'hover' ).parent().removeClass( 'touch-drop' );
-				} );
-
+				e.preventDefault();
 			} );
 		} );
 	}

--- a/js/jquery.theme.js
+++ b/js/jquery.theme.js
@@ -328,6 +328,39 @@ jQuery( function( $ ) {
 		$( 'html, body' ).animate( { scrollTop: 0 } );
 	} );
 
+	// This this is a touch device. We detect this through ontouchstart, msMaxTouchPoints and MaxTouchPoints.
+	if ( 'ontouchstart' in document.documentElement || window.navigator.msMaxTouchPoints || window.navigator.MaxTouchPoints ) {
+		$('body').removeClass('no-touch');
+	}
+	if ( !$( 'body' ).hasClass( 'no-touch' ) ) {
+		if ( /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream ) {
+			$( 'body' ).css( 'cursor', 'pointer' );
+		}
+		$( '.main-navigation #primary-menu').find('.menu-item-has-children > a' ).each( function() {
+			$( this ).click( function( e ) {
+				var link = $( this );
+				e.stopPropagation();
+				link.parent().addClass( 'touch-drop' );
+
+				if ( link.hasClass( 'hover' ) ) {
+					link.unbind( 'click' );
+				} else {
+					link.addClass( 'hover' );
+					e.preventDefault();
+				}
+
+				$( '.main-navigation #primary-menu > .menu-item-has-children:not(.touch-drop) > a' ).click( function() {
+					link.removeClass('hover').parent().removeClass('touch-drop');
+				} );
+
+				$( document ).click( function() {
+					link.removeClass( 'hover' ).parent().removeClass( 'touch-drop' );
+				} );
+
+			} );
+		} );
+	}
+
 } );
 
 ( function( $ ) {

--- a/js/jquery.theme.js
+++ b/js/jquery.theme.js
@@ -328,29 +328,34 @@ jQuery( function( $ ) {
 		$( 'html, body' ).animate( { scrollTop: 0 } );
 	} );
 
-	// This this is a touch device. We detect this through ontouchstart, msMaxTouchPoints and MaxTouchPoints.
+	// Detect if is a touch device. We detect this through ontouchstart, msMaxTouchPoints and MaxTouchPoints.
 	if ( 'ontouchstart' in document.documentElement || window.navigator.msMaxTouchPoints || window.navigator.MaxTouchPoints ) {
 		if ( /iPad|iPhone|iPod/.test( navigator.userAgent ) && ! window.MSStream ) {
 			$( 'body' ).css( 'cursor', 'pointer' );
+			$( 'body' ).addClass( 'ios' );
 		}
-		$( '.main-navigation #primary-menu').find('.menu-item-has-children > a' ).each( function() {
-			$( this ).click( function( e ) {
+
+		$( '.main-navigation #primary-menu' ).find( '.menu-item-has-children > a' ).each( function() {
+			$( this ).on( 'click touchend', function( e ) {
 				var link = $( this );
 				e.stopPropagation();
-
- 				if ( ! link.hasClass( 'hover' ) ) {
-					e.preventDefault();	
- 					// Remove .hover from all other sub menus
- 					$( '.hover' ).removeClass( 'hover' );
-
-					link.addClass( 'hover' );
-
-					// Remove .hover class when user clicks outside of sub menu
-	 				$( document ).click( function() {
-						link.removeClass( 'hover' );
-						link.unbind( 'click' );	
-					} );
+				
+				if ( e.type == 'click' ) {
+					return;
 				}
+
+				if ( ! link.parent().hasClass( 'hover' ) ) {
+					// Remove .hover from all other sub menus
+					$( '.menu-item.hover' ).removeClass( 'hover' );
+					link.parents('.menu-item').addClass( 'hover' );
+					e.preventDefault();
+				}
+
+				// Remove .hover class when user clicks outside of sub menu
+				$( document ).one( 'click', function() {
+					link.parent().removeClass( 'hover' );
+				} );
+
 			} );
 		} );
 	}

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -72,8 +72,16 @@
 			}
 		}
 
-		li:hover > ul,
-		li.focus > ul {
+		@at-root body:not(.ios) & {
+			li:hover > ul,
+			li.focus > ul {
+				opacity: 1;
+				transform: scale(1);
+				visibility: visible;
+			}
+		}
+
+		li.hover > ul {
 			opacity: 1;
 			transform: scale(1);
 			visibility: visible;

--- a/style.css
+++ b/style.css
@@ -575,8 +575,12 @@ a {
         .main-navigation ul .sub-menu li:last-of-type > a,
         .main-navigation ul .children li:last-of-type > a {
           border-bottom: none; }
-    .main-navigation ul li:hover > ul,
-    .main-navigation ul li.focus > ul {
+    body:not(.ios) .main-navigation ul li:hover > ul,
+    body:not(.ios) .main-navigation ul li.focus > ul {
+      opacity: 1;
+      transform: scale(1);
+      visibility: visible; }
+    .main-navigation ul li.hover > ul {
       opacity: 1;
       transform: scale(1);
       visibility: visible; }


### PR DESCRIPTION
This PR adds [these lines](https://github.com/siteorigin/siteorigin-north/blob/1.6.7/js/north.js#L115-L146) from North to Corp. This will allow for websites with the mobile menu disabled to still have sub menus work without issue for users on touch devices.