### PR TITLE
Bottom bar separators

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -43,12 +43,12 @@
 					siteorigin_corp_footer_text();
 
 					if ( function_exists( 'the_privacy_policy_link' ) && siteorigin_setting( 'footer_privacy_policy_link' ) ) {
-						the_privacy_policy_link( '', '.&nbsp;' );
+						the_privacy_policy_link( '<span>', '</span>' );
 					}
 
 					$credit_text = apply_filters(
 						'siteorigin_corp_footer_credits',
-						sprintf( esc_html__( 'Crafted with love by %s.', 'siteorigin-corp' ), '<a href="https://siteorigin.com/">SiteOrigin</a>' )
+						'<span>' . sprintf( esc_html__( 'Crafted with love by %s', 'siteorigin-corp' ), '<a href="https://siteorigin.com/">SiteOrigin</a>' ) . '</span>'
 					);
 
 					if ( ! empty( $credit_text ) ) {

--- a/footer.php
+++ b/footer.php
@@ -45,7 +45,7 @@
 					if ( function_exists( 'the_privacy_policy_link' ) && siteorigin_setting( 'footer_privacy_policy_link' ) ) {
 						the_privacy_policy_link( '', '.&nbsp;' );
 					}
-					
+
 					$credit_text = apply_filters(
 						'siteorigin_corp_footer_credits',
 						sprintf( esc_html__( 'Crafted with love by %s.', 'siteorigin-corp' ), '<a href="https://siteorigin.com/">SiteOrigin</a>' )

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1585,7 +1585,7 @@ function siteorigin_corp_settings_defaults( $defaults ) {
 	$defaults['sidebar_position']                     = 'right';
 	$defaults['sidebar_width']                        = '34%%';
 
-	$defaults['footer_text']                          = esc_html__( '{year} &copy; {sitename}.', 'siteorigin-corp' );
+	$defaults['footer_text']                          = esc_html__( '{year} &copy; {sitename}', 'siteorigin-corp' );
 	$defaults['footer_privacy_policy_link']           = true;
 	$defaults['footer_widget_title']                  = '#ffffff';
 	$defaults['footer_widget_text']                   = '#b4b5b8';

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -537,9 +537,9 @@ function siteorigin_corp_footer_text() {
 	$text = str_replace(
 		array( '{sitename}', '{year}' ),
 		array( get_bloginfo( 'sitename' ), date( 'Y' ) ),
-		$text
+		'<span>' . $text . '</span>'
 	);
-	echo wp_kses_post( $text ) . '&nbsp;';
+	echo wp_kses_post( $text );
 }
 endif;
 

--- a/sass/site/_footer.scss
+++ b/sass/site/_footer.scss
@@ -55,6 +55,22 @@
 	.site-info {
 		font-size: 13px;
 		text-align: left;
+
+		span {
+			
+			&:after {
+				content: "\002d";
+				display: inline-block;
+				padding: 0 5px;
+			}
+
+			&:last-of-type {
+				
+				&:after {
+					content: none;
+				}
+			}
+		}
 		
 		@media (max-width: 768px) {
 			float: none;

--- a/style.css
+++ b/style.css
@@ -2834,6 +2834,12 @@ body:not(.single) .entry-content p:only-of-type {
   .site-footer .site-info {
     font-size: 13px;
     text-align: left; }
+    .site-footer .site-info span:after {
+      content: "\002d";
+      display: inline-block;
+      padding: 0 5px; }
+    .site-footer .site-info span:last-of-type:after {
+      content: none; }
     @media (max-width: 768px) {
       .site-footer .site-info {
         float: none;


### PR DESCRIPTION
Bottom bar items are:

1. Bottom bar text (copyright).
2. Privacy policy link
3. Footer attribution.

Currently, these items are separated by a period. This PR changes the separator to a CSS hyphen. This will allow more flexibility in changing the separator for users that would like to do so.