### PR TITLE
Offset layout fix single post meta display

### DIFF
--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -12,7 +12,7 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
-	<?php if ( ! siteorigin_corp_is_post_loop_widget() && siteorigin_setting( 'blog_archive_layout' ) == 'offset' || siteorigin_corp_is_post_loop_template( 'offset' ) ) : ?>
+	<?php if ( ! is_single() && ! siteorigin_corp_is_post_loop_widget() && siteorigin_setting( 'blog_archive_layout' ) == 'offset' || siteorigin_corp_is_post_loop_template( 'offset' ) ) : ?>
 		<div class="entry-offset">
 			<?php siteorigin_corp_offset_post_meta(); ?>
 		</div>
@@ -37,7 +37,7 @@
 			<?php if ( 'post' === get_post_type() ) : ?>
 				<div class="entry-meta">
 					<?php 
-					if ( ! siteorigin_corp_is_post_loop_widget() && siteorigin_setting( 'blog_archive_layout' ) == 'offset' || siteorigin_corp_is_post_loop_template( 'offset' ) ) :
+					if ( ! is_single() && ! siteorigin_corp_is_post_loop_widget() && siteorigin_setting( 'blog_archive_layout' ) == 'offset' || siteorigin_corp_is_post_loop_template( 'offset' ) ) :
 						siteorigin_corp_posted_on();
 					else :
 						siteorigin_corp_post_meta();


### PR DESCRIPTION
When Offset is selected as the blog post layout in the theme settings the offset meta appears on the single post page and the existing meta under the title doesn't display full info as it should.

Choose the offset layout in the theme settings and then, test both the posts page, single page and also the offset layout used in the Post Loop widget. Any other testing you can think of, please do it. Thanks!