### PR TITLE
Footer widget text color setting

### DIFF
--- a/sass/site/_footer.scss
+++ b/sass/site/_footer.scss
@@ -20,6 +20,7 @@
 
 		.widget {
 			box-sizing: content-box;
+			color: $color__footer-widget-text;
 			margin: 0 2.75% 95px 0;
 			float: left;
 
@@ -27,10 +28,6 @@
 				color: $color__footer-widget-title;
 				font-size: 1.0666em;
 				font-weight: 500;
-
-				~ * {
-					color: $color__footer-widget-text;
-				}
 			}
 
 			a {

--- a/sass/site/_footer.scss
+++ b/sass/site/_footer.scss
@@ -1,11 +1,11 @@
 .site-footer {
 	background: $color__footer-background;
 	margin-top: $footer__margin;
-	
+
 	.no-footer-margin & {
 		margin-top: 0;
 	}
-	
+
 	.widgets {
 		@include clearfix;
 		padding-top: $footer__padding;
@@ -22,12 +22,12 @@
 			box-sizing: content-box;
 			margin: 0 2.75% 95px 0;
 			float: left;
-			
+
 			.widget-title {
 				color: $color__footer-widget-title;
 				font-size: 1.0666em;
 				font-weight: 500;
-				
+
 				~ * {
 					color: $color__footer-widget-text;
 				}
@@ -35,7 +35,7 @@
 
 			a {
 				color: $color__footer-widget-link;
-				
+
 				&:hover {
 					color: $color__footer-widget-link-hover;
 				}
@@ -61,7 +61,7 @@
 		text-align: left;
 
 		span {
-			
+
 			&:after {
 				content: "\002d";
 				display: inline-block;
@@ -75,7 +75,7 @@
 				}
 			}
 		}
-		
+
 		@media (max-width: 768px) {
 			float: none;
 			text-align: center;
@@ -91,7 +91,7 @@
 
 		a {
 			color: $color__bottom-bar-link;
-			
+
 			&:hover {
 				color: $color__bottom-bar-link-hover;
 			}
@@ -108,7 +108,7 @@
 			-webkit-justify-content: space-between;
 			justify-content: space-between;
 			width: 100%;
-				
+
 			@media (max-width: 768px) {
 				flex-direction: column;
 			}
@@ -123,14 +123,14 @@
 		.widget {
 			display: inline-block;
 			margin: 0 0 0 15px;
-			
+
 			@media (max-width: 768px) {
 				margin: 0;
 				padding-top: 15px;
 				text-align: center;
 				width: 100%;
 			}
-			
+
 			a {
 
 			}

--- a/style.css
+++ b/style.css
@@ -2825,14 +2825,13 @@ body:not(.single) .entry-content p:only-of-type {
       width: 7.525%; }
     .site-footer .widgets .widget {
       box-sizing: content-box;
+      color: #b4b5b8;
       margin: 0 2.75% 95px 0;
       float: left; }
       .site-footer .widgets .widget .widget-title {
         color: #fff;
         font-size: 1.0666em;
         font-weight: 500; }
-        .site-footer .widgets .widget .widget-title ~ * {
-          color: #b4b5b8; }
       .site-footer .widgets .widget a {
         color: #ffffff; }
         .site-footer .widgets .widget a:hover {


### PR DESCRIPTION
Currently, we're targetting the footer text color setting by focussing on selectors that follow the widget title. The issue with that is that some users leave the widget title setting blank. Please, test the widget title and widget text settings with and without the widget title present.