### PR TITLE
Ensure the product overlay works on cart

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -71,7 +71,7 @@ function siteorigin_corp_body_classes( $classes ) {
 	}
 
 	// WooCommerce archive Quick View and Add to Cart.
-	if ( function_exists( 'is_woocommerce' ) && ( is_shop() || is_product_category() || is_product_tag() || is_product() ) && ( siteorigin_setting( 'woocommerce_quick_view' ) || siteorigin_setting( 'woocommerce_add_to_cart' ) ) ) {
+	if ( function_exists( 'is_woocommerce' ) && ( is_woocommerce() || is_cart() ) && ( siteorigin_setting( 'woocommerce_quick_view' ) || siteorigin_setting( 'woocommerce_add_to_cart' ) ) ) {
 		$classes[] = 'woocommerce-product-overlay';
 	}
 

--- a/sass/woocommerce/_archive.scss
+++ b/sass/woocommerce/_archive.scss
@@ -321,7 +321,7 @@
 						visibility: visible;
 					}
 
-					@at-root .woocommerce-product-overlay#{&} img {
+					@at-root .woocommerce-product-overlay .products .product .loop-product-thumbnail:hover img {
 						opacity: 0.3;
 					}
 				}

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -502,7 +502,7 @@ input.button.added:after,
       .woocommerce .products .product .loop-product-thumbnail:hover .product_type_external {
         opacity: 1;
         visibility: visible; }
-      .woocommerce-product-overlay.woocommerce .products .product .loop-product-thumbnail:hover img {
+      .woocommerce-product-overlay .products .product .loop-product-thumbnail:hover img {
         opacity: 0.3; }
     .woocommerce .products .product img {
       display: block;


### PR DESCRIPTION
Currently, the product overlay doesn't appear on the cart page.

![Screenshot 2019-09-22 at 16 54 28](https://user-images.githubusercontent.com/789159/65389738-b204d600-dd59-11e9-8daa-dd1c2498b27d.png)

To replicate this, add this product to the cart: https://demo.siteorigin.com/corp/product/hoodie-with-logo/

This PR ensures that when hovering over YOU MAY BE INTERESTED IN…products on the cart page, the overlay is in place.