### PR TITLE
Smooth scroll and header offset WC review link

### DIFF
--- a/js/jquery.theme.js
+++ b/js/jquery.theme.js
@@ -142,7 +142,7 @@ jQuery( function( $ ) {
 	};
 
 	$( window ).load( function() {
-		$( '#site-navigation a[href*="#"]:not([href="#"]), .comments-link a[href*="#"]:not([href="#"]), .corp-scroll[href*="#"]:not([href="#"])' ).siteoriginCorpSmoothScroll();
+		$( '#site-navigation a[href*="#"]:not([href="#"]), .comments-link a[href*="#"]:not([href="#"]), .woocommerce-review-link[href*="#"]:not([href="#"]), .corp-scroll[href*="#"]:not([href="#"])' ).siteoriginCorpSmoothScroll();
 	} );
 
 	// Adjust for sticky header when linking from external anchors.


### PR DESCRIPTION
View a product with a review and click on the review link.

<img width="280" alt="Cap_-_SiteOrigin" src="https://user-images.githubusercontent.com/789159/65833844-01f11900-e2d5-11e9-87b3-dd597f49c4ae.png">

The link should now be smooth scrolled and the anchor offset.