### PR TITLE
Added settings for WC archive buttons non-hover

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -31,3 +31,16 @@ function siteorigin_corp_excerpt_more( $more ) {
 }
 endif;
 add_filter( 'excerpt_more', 'siteorigin_corp_excerpt_more' );
+
+if ( ! function_exists( 'siteorigin_corp_woocommerce_archive_product_image_buttons' ) ) :
+/**
+ * Archive product image buttons.
+ */
+function siteorigin_corp_woocommerce_archive_product_image_buttons() { ?>
+	<?php if ( siteorigin_setting( 'woocommerce_quick_view' ) ) {
+		siteorigin_corp_woocommerce_quick_view_button();
+	} if ( siteorigin_setting( 'woocommerce_add_to_cart' ) ) {
+		woocommerce_template_loop_add_to_cart();
+	} ?>
+<?php }
+endif;

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -71,7 +71,7 @@ function siteorigin_corp_body_classes( $classes ) {
 	}
 
 	// WooCommerce archive Quick View and Add to Cart.
-	if ( function_exists( 'is_woocommerce' ) && ( is_woocommerce() || is_cart() ) && ( siteorigin_setting( 'woocommerce_quick_view' ) || siteorigin_setting( 'woocommerce_add_to_cart' ) ) ) {
+	if ( function_exists( 'is_woocommerce' ) && ( is_woocommerce() || is_cart() ) && ( siteorigin_setting( 'woocommerce_quick_view' ) && siteorigin_setting( 'woocommerce_quick_view_location' ) == 'hover' || siteorigin_setting( 'woocommerce_add_to_cart' ) && siteorigin_setting( 'woocommerce_add_to_cart_location' ) == 'hover' ) ) {
 		$classes[] = 'woocommerce-product-overlay';
 	}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -477,12 +477,28 @@ function siteorigin_corp_woocommerce_settings( $settings ) {
 				'quick_view' => array(
 					'type'        => 'checkbox',
 					'label'       => esc_html__( 'Quick View', 'siteorigin-corp' ),
-					'description' => esc_html__( 'Display a Quick View button on hover on product archive pages.', 'siteorigin-corp' ),
+					'description' => esc_html__( 'Display a product Quick View button on product archive pages.', 'siteorigin-corp' ),
+				),
+				'quick_view_location' => array(
+					'type'        => 'radio',
+					'label'       => esc_html__( 'Quick View Location', 'siteorigin-corp' ),
+					'options' => array(
+						'hover'  => esc_html__( 'Thumbnail Hover', 'siteorigin-corp' ),
+						'below'  => esc_html__( 'Below Thumbnail', 'siteorigin-corp' ),
+					),
 				),
 				'add_to_cart' => array(
 					'type'        => 'checkbox',
 					'label'       => esc_html__( 'Add to Cart', 'siteorigin-corp' ),
-					'description' => esc_html__( 'Display an Add to Cart button on hover on product archive pages.', 'siteorigin-corp' ),
+					'description' => esc_html__( 'Display an Add to Cart button on product archive pages.', 'siteorigin-corp' ),
+				),
+				'add_to_cart_location' => array(
+					'type'        => 'radio',
+					'label'       => esc_html__( 'Add to Cart Location', 'siteorigin-corp' ),
+					'options' => array(
+						'hover'  => esc_html__( 'Thumbnail Hover', 'siteorigin-corp' ),
+						'below'  => esc_html__( 'Below Thumbnail', 'siteorigin-corp' ),
+					),
 				),
 			)
 		)
@@ -1645,8 +1661,10 @@ function siteorigin_corp_settings_defaults( $defaults ) {
 	$defaults['woocommerce_shop_sidebar']             = 'right';
 	$defaults['woocommerce_product_gallery']          = 'slider-lightbox';
 	$defaults['woocommerce_mini_cart']                = false;
-	$defaults['woocommerce_add_to_cart']              = false;
 	$defaults['woocommerce_quick_view']               = false;
+	$defaults['woocommerce_quick_view_location']      = 'hover';
+	$defaults['woocommerce_add_to_cart']              = false;
+	$defaults['woocommerce_add_to_cart_location']     = 'hover';
 
 	return $defaults;
 }

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -480,7 +480,7 @@ function siteorigin_corp_woocommerce_settings( $settings ) {
 					'description' => esc_html__( 'Display a product Quick View button on product archive pages.', 'siteorigin-corp' ),
 				),
 				'quick_view_location' => array(
-					'type'        => 'radio',
+					'type'        => 'select',
 					'label'       => esc_html__( 'Quick View Location', 'siteorigin-corp' ),
 					'options' => array(
 						'hover'  => esc_html__( 'Thumbnail Hover', 'siteorigin-corp' ),
@@ -493,7 +493,7 @@ function siteorigin_corp_woocommerce_settings( $settings ) {
 					'description' => esc_html__( 'Display an Add to Cart button on product archive pages.', 'siteorigin-corp' ),
 				),
 				'add_to_cart_location' => array(
-					'type'        => 'radio',
+					'type'        => 'select',
 					'label'       => esc_html__( 'Add to Cart Location', 'siteorigin-corp' ),
 					'options' => array(
 						'hover'  => esc_html__( 'Thumbnail Hover', 'siteorigin-corp' ),

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1198,14 +1198,22 @@ function siteorigin_corp_wc_settings_custom_css( $css ) {
 	.woocommerce a .star-rating {
 	color: ${typography_accent};
 	}
+	.woocommerce .products .product .loop-product-thumbnail .added_to_cart {
+	background: ${typography_accent};
+	}
+	.woocommerce .products .product .loop-product-thumbnail .added_to_cart:hover {
+	background: .rgba( ${typography_accent}, .8);
+	}
 	.woocommerce .products .product .woocommerce-loop-product__title:hover,.woocommerce .products .product .woocommerce-loop-category__title:hover {
 	color: ${typography_accent};
 	}
-	.woocommerce .products .product .added_to_cart {
-	background: ${typography_accent};
+	.woocommerce .products .product > .button,.woocommerce .products .product .panel-grid-cell .button {
+	border-color: ${typography_heading};
+	color: ${typography_heading};
 	}
-	.woocommerce .products .product .added_to_cart:hover {
-	background: .rgba( ${typography_accent}, .8);
+	.woocommerce .products .product > .button:hover,.woocommerce .products .product .panel-grid-cell .button:hover {
+	border-color: ${typography_accent};
+	color: ${typography_accent};
 	}
 	.woocommerce .price {
 	color: ${typography_text};
@@ -1213,38 +1221,38 @@ function siteorigin_corp_wc_settings_custom_css( $css ) {
 	.woocommerce .price ins {
 	color: ${typography_accent};
 	}
-	.woocommerce .product .summary .woocommerce-review-link,.woocommerce .product .product-info-wrapper .woocommerce-review-link {
+	.woocommerce .product .woocommerce-review-link {
 	color: ${typography_secondary_text};
 	}
-	.woocommerce .product .summary .woocommerce-review-link:hover,.woocommerce .product .product-info-wrapper .woocommerce-review-link:hover {
+	.woocommerce .product .woocommerce-review-link:hover {
 	color: ${typography_accent};
 	}
-	.woocommerce .product .summary .variations .label label,.woocommerce .product .product-info-wrapper .variations .label label {
+	.woocommerce .product .variations .label label {
 	color: ${typography_heading};
 	}
-	.woocommerce .product .summary .variations .reset_variations,.woocommerce .product .product-info-wrapper .variations .reset_variations {
+	.woocommerce .product .variations .reset_variations {
 	color: ${typography_text};
 	}
-	.woocommerce .product .summary .variations .reset_variations:hover,.woocommerce .product .product-info-wrapper .variations .reset_variations:hover {
+	.woocommerce .product .variations .reset_variations:hover {
 	color: ${typography_accent};
 	}
-	.woocommerce .product .summary .woocommerce-grouped-product-list td a,.woocommerce .product .product-info-wrapper .woocommerce-grouped-product-list td a {
+	.woocommerce .product .woocommerce-grouped-product-list td a {
 	color: ${typography_text};
 	}
-	.woocommerce .product .summary .woocommerce-grouped-product-list td a:hover,.woocommerce .product .product-info-wrapper .woocommerce-grouped-product-list td a:hover {
+	.woocommerce .product .woocommerce-grouped-product-list td a:hover {
 	color: ${typography_accent};
 	}
-	.woocommerce .product .summary .stock,.woocommerce .product .product-info-wrapper .stock {
+	.woocommerce .product .stock {
 	color: ${typography_accent};
 	}
-	.woocommerce .product .summary .product_meta,.woocommerce .product .product-info-wrapper .product_meta {
+	.woocommerce .product .product_meta {
 	border-top: 1px solid ${typography_border};
 	color: ${typography_text};
 	}
-	.woocommerce .product .summary .product_meta a,.woocommerce .product .product-info-wrapper .product_meta a {
+	.woocommerce .product .product_meta a {
 	color: ${typography_heading};
 	}
-	.woocommerce .product .summary .product_meta a:hover,.woocommerce .product .product-info-wrapper .product_meta a:hover {
+	.woocommerce .product .product_meta a:hover {
 	color: ${typography_accent};
 	}
 	.woocommerce .product .woocommerce-tabs h2 {

--- a/sass/woocommerce/_archive.scss
+++ b/sass/woocommerce/_archive.scss
@@ -455,18 +455,13 @@
 				font-size: 14px;
 				letter-spacing: 1px;
 				line-height: normal;
-				margin: 6px 10px 0 0;
+				margin: 6px 5px 0;
 				padding: 9px 25px;
 				transition: .3s;
 
 				&:hover {
 					border-color: $color__accent;
 					color: $color__accent;
-				}
-
-				&:last-of-type,
-				&:only-of-type {
-					margin-right: 0;
 				}
 			}
 

--- a/sass/woocommerce/_archive.scss
+++ b/sass/woocommerce/_archive.scss
@@ -325,7 +325,87 @@
 						opacity: 0.3;
 					}
 				}
-			}
+
+				.add_to_cart_button,
+				.product-quick-view-button,
+				.product_type_grouped,
+				.product_type_variable,
+				.product_type_external,
+				.added_to_cart {
+					display: block;
+					font-size: 14px;
+					transition: .3s;
+					left: 50%;
+					opacity: 0;
+					position: absolute;
+					transform: translateX( -50% );
+					visibility: hidden;
+					white-space: nowrap;
+				}
+
+				.add_to_cart_button,
+				.product_type_grouped,
+				.product_type_variable,
+				.product_type_external {
+					bottom: 20%;
+				}
+
+				.product-quick-view-button {
+					background: #656970;
+					border-radius: 50%;
+					content: "";
+					display: block;
+					height: 40px;
+					top: 20%;
+					width: 40px;
+
+					&:hover {
+						background: rgba(101, 105, 112, .8);
+					}
+
+					svg {
+						height: 16px;
+						margin-top: 12px;
+						width: 16px;
+
+						path {
+							fill: #fff;
+						}
+					}
+				}
+
+				// Select Options button.
+				.product_type_variable {
+					padding: 11px 15px;
+				}
+
+				// Added to Cart button.
+				.added_to_cart {
+					background: $color__accent;
+					bottom: 10px;
+					color: #fff;
+					font-size: 12px;
+					font-weight: 500;
+					letter-spacing: .5px;
+					opacity: 1;
+					padding: 6px 12px 5px;
+					text-transform: uppercase;
+					visibility: visible;
+
+					&:hover {
+						background: rgba($color__accent, .8);
+						color: #fff;
+					}
+				}
+
+				// Checking for two items within .loop-product-thumbnail.
+				a:first-child:nth-last-child(2),
+				a:first-child:nth-last-child(2) ~ a {
+					bottom: auto;
+					top: 50%;
+					transform: translate(-50%, -50%);
+				}
+			} // End .loop-product-thumbnail
 
 			// Product image.
 			img {
@@ -365,75 +445,34 @@
 				margin-bottom: 0;
 			}
 
-			.add_to_cart_button,
-			.product-quick-view-button,
-			.product_type_grouped,
-			.product_type_variable,
-			.product_type_external,
-			.added_to_cart {
-				display: block;
+			// > .button {
+			// 	background: #e4e6eb;
+			// 	color: $color__text-medium;
+			// 	display: inline-block;
+			// }
+
+			> .button,
+			.panel-grid-cell .button {
+				background: transparent;
+				border: 2px solid;
+				border-color: $color__text-dark;
+				color: $color__text-dark;
+				display: inline-block;
 				font-size: 14px;
+				letter-spacing: 1px;
+				line-height: normal;
+				margin: 6px 10px 0 0;
+				padding: 9px 25px;
 				transition: .3s;
-				left: 50%;
-				opacity: 0;
-				position: absolute;
-				transform: translateX( -50% );
-				visibility: hidden;
-				white-space: nowrap;
-			}
-
-			.add_to_cart_button,
-			.product_type_grouped,
-			.product_type_variable,
-			.product_type_external {
-				bottom: 20%;
-			}
-
-			.product-quick-view-button {
-				background: #656970;
-				border-radius: 50%;
-				content: "";
-				display: block;
-				height: 40px;
-				top: 20%;
-				width: 40px;
 
 				&:hover {
-					background: rgba(101, 105, 112, .8);
+					border-color: $color__accent;
+					color: $color__accent;
 				}
 
-				svg {
-					height: 16px;
-					margin-top: 12px;
-					width: 16px;
-
-					path {
-						fill: #fff;
-					}
-				}
-			}
-
-			// Select Options button.
-			.product_type_variable {
-				padding: 11px 15px;
-			}
-
-			// Added to Cart button.
-			.added_to_cart {
-				background: $color__accent;
-				bottom: 10px;
-				color: #fff;
-				font-size: 12px;
-				font-weight: 500;
-				letter-spacing: .5px;
-				opacity: 1;
-				padding: 6px 12px 5px;
-				text-transform: uppercase;
-				visibility: visible;
-
-				&:hover {
-					background: rgba($color__accent, .8);
-					color: #fff;
+				&:last-of-type,
+				&:only-of-type {
+					margin-right: 0;
 				}
 			}
 		}

--- a/sass/woocommerce/_archive.scss
+++ b/sass/woocommerce/_archive.scss
@@ -445,12 +445,6 @@
 				margin-bottom: 0;
 			}
 
-			// > .button {
-			// 	background: #e4e6eb;
-			// 	color: $color__text-medium;
-			// 	display: inline-block;
-			// }
-
 			> .button,
 			.panel-grid-cell .button {
 				background: transparent;
@@ -474,6 +468,12 @@
 				&:only-of-type {
 					margin-right: 0;
 				}
+			}
+
+			.added_to_cart {
+				display: block;
+				font-size: 14px;
+				margin-top: 6px;
 			}
 		}
 	}

--- a/sass/woocommerce/_buttons.scss
+++ b/sass/woocommerce/_buttons.scss
@@ -18,7 +18,7 @@ input.button,
 		font-size: .9em; 
 		font-family: 'WooCommerce';
 		content: '\e017';
-		margin-left: 1em;
+		margin-left: 0.5em;
 		vertical-align: baseline;
 	}
 }

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -504,6 +504,63 @@ input.button.added:after,
         visibility: visible; }
       .woocommerce-product-overlay .products .product .loop-product-thumbnail:hover img {
         opacity: 0.3; }
+      .woocommerce .products .product .loop-product-thumbnail .add_to_cart_button,
+      .woocommerce .products .product .loop-product-thumbnail .product-quick-view-button,
+      .woocommerce .products .product .loop-product-thumbnail .product_type_grouped,
+      .woocommerce .products .product .loop-product-thumbnail .product_type_variable,
+      .woocommerce .products .product .loop-product-thumbnail .product_type_external,
+      .woocommerce .products .product .loop-product-thumbnail .added_to_cart {
+        display: block;
+        font-size: 14px;
+        transition: .3s;
+        left: 50%;
+        opacity: 0;
+        position: absolute;
+        transform: translateX(-50%);
+        visibility: hidden;
+        white-space: nowrap; }
+      .woocommerce .products .product .loop-product-thumbnail .add_to_cart_button,
+      .woocommerce .products .product .loop-product-thumbnail .product_type_grouped,
+      .woocommerce .products .product .loop-product-thumbnail .product_type_variable,
+      .woocommerce .products .product .loop-product-thumbnail .product_type_external {
+        bottom: 20%; }
+      .woocommerce .products .product .loop-product-thumbnail .product-quick-view-button {
+        background: #656970;
+        border-radius: 50%;
+        content: "";
+        display: block;
+        height: 40px;
+        top: 20%;
+        width: 40px; }
+        .woocommerce .products .product .loop-product-thumbnail .product-quick-view-button:hover {
+          background: rgba(101, 105, 112, 0.8); }
+        .woocommerce .products .product .loop-product-thumbnail .product-quick-view-button svg {
+          height: 16px;
+          margin-top: 12px;
+          width: 16px; }
+          .woocommerce .products .product .loop-product-thumbnail .product-quick-view-button svg path {
+            fill: #fff; }
+      .woocommerce .products .product .loop-product-thumbnail .product_type_variable {
+        padding: 11px 15px; }
+      .woocommerce .products .product .loop-product-thumbnail .added_to_cart {
+        background: #f14e4e;
+        bottom: 10px;
+        color: #fff;
+        font-size: 12px;
+        font-weight: 500;
+        letter-spacing: .5px;
+        opacity: 1;
+        padding: 6px 12px 5px;
+        text-transform: uppercase;
+        visibility: visible; }
+        .woocommerce .products .product .loop-product-thumbnail .added_to_cart:hover {
+          background: rgba(241, 78, 78, 0.8);
+          color: #fff; }
+      .woocommerce .products .product .loop-product-thumbnail a:first-child:nth-last-child(2),
+      .woocommerce .products .product .loop-product-thumbnail a:first-child:nth-last-child(2) ~ a {
+        bottom: auto;
+        top: 50%;
+        transform: translate(-50%, -50%); }
     .woocommerce .products .product img {
       display: block;
       margin: 0 auto;
@@ -528,58 +585,27 @@ input.button.added:after,
       display: block;
       font-size: 14px;
       margin-bottom: 0; }
-    .woocommerce .products .product .add_to_cart_button,
-    .woocommerce .products .product .product-quick-view-button,
-    .woocommerce .products .product .product_type_grouped,
-    .woocommerce .products .product .product_type_variable,
-    .woocommerce .products .product .product_type_external,
-    .woocommerce .products .product .added_to_cart {
-      display: block;
+    .woocommerce .products .product > .button,
+    .woocommerce .products .product .panel-grid-cell .button {
+      background: transparent;
+      border: 2px solid;
+      border-color: #2d2d2d;
+      color: #2d2d2d;
+      display: inline-block;
       font-size: 14px;
-      transition: .3s;
-      left: 50%;
-      opacity: 0;
-      position: absolute;
-      transform: translateX(-50%);
-      visibility: hidden;
-      white-space: nowrap; }
-    .woocommerce .products .product .add_to_cart_button,
-    .woocommerce .products .product .product_type_grouped,
-    .woocommerce .products .product .product_type_variable,
-    .woocommerce .products .product .product_type_external {
-      bottom: 20%; }
-    .woocommerce .products .product .product-quick-view-button {
-      background: #656970;
-      border-radius: 50%;
-      content: "";
-      display: block;
-      height: 40px;
-      top: 20%;
-      width: 40px; }
-      .woocommerce .products .product .product-quick-view-button:hover {
-        background: rgba(101, 105, 112, 0.8); }
-      .woocommerce .products .product .product-quick-view-button svg {
-        height: 16px;
-        margin-top: 12px;
-        width: 16px; }
-        .woocommerce .products .product .product-quick-view-button svg path {
-          fill: #fff; }
-    .woocommerce .products .product .product_type_variable {
-      padding: 11px 15px; }
-    .woocommerce .products .product .added_to_cart {
-      background: #f14e4e;
-      bottom: 10px;
-      color: #fff;
-      font-size: 12px;
-      font-weight: 500;
-      letter-spacing: .5px;
-      opacity: 1;
-      padding: 6px 12px 5px;
-      text-transform: uppercase;
-      visibility: visible; }
-      .woocommerce .products .product .added_to_cart:hover {
-        background: rgba(241, 78, 78, 0.8);
-        color: #fff; }
+      letter-spacing: 1px;
+      line-height: normal;
+      margin: 6px 10px 0 0;
+      padding: 9px 25px;
+      transition: .3s; }
+      .woocommerce .products .product > .button:hover,
+      .woocommerce .products .product .panel-grid-cell .button:hover {
+        border-color: #f14e4e;
+        color: #f14e4e; }
+      .woocommerce .products .product > .button:last-of-type, .woocommerce .products .product > .button:only-of-type,
+      .woocommerce .products .product .panel-grid-cell .button:last-of-type,
+      .woocommerce .products .product .panel-grid-cell .button:only-of-type {
+        margin-right: 0; }
 
 .woocommerce .price {
   color: #626262; }

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -595,17 +595,13 @@ input.button.added:after,
       font-size: 14px;
       letter-spacing: 1px;
       line-height: normal;
-      margin: 6px 10px 0 0;
+      margin: 6px 5px 0;
       padding: 9px 25px;
       transition: .3s; }
       .woocommerce .products .product > .button:hover,
       .woocommerce .products .product .panel-grid-cell .button:hover {
         border-color: #f14e4e;
         color: #f14e4e; }
-      .woocommerce .products .product > .button:last-of-type, .woocommerce .products .product > .button:only-of-type,
-      .woocommerce .products .product .panel-grid-cell .button:last-of-type,
-      .woocommerce .products .product .panel-grid-cell .button:only-of-type {
-        margin-right: 0; }
     .woocommerce .products .product .added_to_cart {
       display: block;
       font-size: 14px;

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -102,7 +102,7 @@ input.button.added:after,
   font-size: .9em;
   font-family: 'WooCommerce';
   content: '\e017';
-  margin-left: 1em;
+  margin-left: 0.5em;
   vertical-align: baseline; }
 
 /*--------------------------------------------------------------
@@ -606,6 +606,10 @@ input.button.added:after,
       .woocommerce .products .product .panel-grid-cell .button:last-of-type,
       .woocommerce .products .product .panel-grid-cell .button:only-of-type {
         margin-right: 0; }
+    .woocommerce .products .product .added_to_cart {
+      display: block;
+      font-size: 14px;
+      margin-top: 6px; }
 
 .woocommerce .price {
   color: #626262; }

--- a/woocommerce/template-tags.php
+++ b/woocommerce/template-tags.php
@@ -32,7 +32,7 @@ function siteorigin_corp_woocommerce_change_hooks() {
 	add_action( 'siteorigin_corp_woocommerce_quick_view_title', 'woocommerce_template_single_rating', 15 );
 	add_action( 'siteorigin_corp_woocommerce_quick_view_content', 'woocommerce_template_single_price' );
 	add_action( 'siteorigin_corp_woocommerce_quick_view_content', 'woocommerce_template_single_excerpt', 15 );
-	add_action( 'siteorigin_corp_woocommerce_quick_view_content', 'woocommerce_template_single_add_to_cart', 20 );	
+	add_action( 'siteorigin_corp_woocommerce_quick_view_content', 'woocommerce_template_single_add_to_cart', 20 );
 
 	// Remove store notice hook.
 	remove_action( 'wp_footer', 'woocommerce_demo_store' );
@@ -67,25 +67,30 @@ function siteorigin_corp_woocommerce_archive_product_image() { ?>
 		<?php woocommerce_template_loop_product_link_open(); ?>
 		<?php woocommerce_template_loop_product_thumbnail(); ?>
 		<?php woocommerce_template_loop_product_link_close(); ?>
-		<?php if ( siteorigin_setting( 'woocommerce_quick_view' ) || siteorigin_setting( 'woocommerce_add_to_cart' ) ) : ?>
-			<?php siteorigin_corp_woocommerce_archive_product_image_buttons(); ?>
-		<?php endif; ?>
+		<?php if ( siteorigin_setting( 'woocommerce_quick_view' ) && siteorigin_setting( 'woocommerce_quick_view_location' ) == 'hover' ) {
+			siteorigin_corp_woocommerce_quick_view_button();
+		}
+		if ( siteorigin_setting( 'woocommerce_add_to_cart' ) && siteorigin_setting( 'woocommerce_add_to_cart_location' ) == 'hover' ) {
+			woocommerce_template_loop_add_to_cart();
+		} ?>
 	</div>
 <?php }
 endif;
 
-if ( ! function_exists( 'siteorigin_corp_woocommerce_archive_product_image_buttons' ) ) :
+if ( ! function_exists( 'siteorigin_corp_woocommerce_archive_buttons' ) ) :
 /**
  * Archive product image buttons.
  */
-function siteorigin_corp_woocommerce_archive_product_image_buttons() { ?>
-	<?php if ( siteorigin_setting( 'woocommerce_quick_view' ) ) {
+function siteorigin_corp_woocommerce_archive_buttons() {
+	if ( siteorigin_setting( 'woocommerce_quick_view' ) && siteorigin_setting( 'woocommerce_quick_view_location' ) == 'below' ) {
 		siteorigin_corp_woocommerce_quick_view_button();
-	} if ( siteorigin_setting( 'woocommerce_add_to_cart' ) ) {
+	}
+	if ( siteorigin_setting( 'woocommerce_add_to_cart' ) && siteorigin_setting( 'woocommerce_add_to_cart_location' ) == 'below' ) {
 		woocommerce_template_loop_add_to_cart();
-	} ?>
-<?php }
+	}
+}
 endif;
+add_action( 'woocommerce_after_shop_loop_item', 'siteorigin_corp_woocommerce_archive_buttons' );
 
 if ( ! function_exists( 'siteorigin_corp_woocommerce_description_title' ) ) :
 /**
@@ -148,7 +153,11 @@ if ( ! function_exists( 'siteorigin_corp_woocommerce_quick_view_button' ) ) :
  */
 function siteorigin_corp_woocommerce_quick_view_button() {
 	global $product;
-	echo '<a href="#" id="product-id-' . $product->get_id() . '" class="product-quick-view-button" data-product-id="' . $product->get_id() . '"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="26" height="28" viewBox="0 0 26 28"><path d="M18 13c0-3.859-3.141-7-7-7s-7 3.141-7 7 3.141 7 7 7 7-3.141 7-7zM26 26c0 1.094-0.906 2-2 2-0.531 0-1.047-0.219-1.406-0.594l-5.359-5.344c-1.828 1.266-4.016 1.937-6.234 1.937-6.078 0-11-4.922-11-11s4.922-11 11-11 11 4.922 11 11c0 2.219-0.672 4.406-1.937 6.234l5.359 5.359c0.359 0.359 0.578 0.875 0.578 1.406z"></path></svg></a>';
+	if ( siteorigin_setting( 'woocommerce_quick_view_location' ) == 'hover' ) {
+		echo '<a href="#" id="product-id-' . $product->get_id() . '" class="product-quick-view-button" data-product-id="' . $product->get_id() . '"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="26" height="28" viewBox="0 0 26 28"><path d="M18 13c0-3.859-3.141-7-7-7s-7 3.141-7 7 3.141 7 7 7 7-3.141 7-7zM26 26c0 1.094-0.906 2-2 2-0.531 0-1.047-0.219-1.406-0.594l-5.359-5.344c-1.828 1.266-4.016 1.937-6.234 1.937-6.078 0-11-4.922-11-11s4.922-11 11-11 11 4.922 11 11c0 2.219-0.672 4.406-1.937 6.234l5.359 5.359c0.359 0.359 0.578 0.875 0.578 1.406z"></path></svg></a>';
+	} else {
+		echo '<a href="#" id="product-id-' . $product->get_id() . '" class="button product-quick-view-button" data-product-id="' . $product->get_id() . '">' . esc_html__( 'Quick View', 'siteorigin-corp' ) . '</a>';
+	}
 }
 endif;
 


### PR DESCRIPTION
Resolves https://github.com/siteorigin/siteorigin-corp/issues/86 and https://github.com/siteorigin/siteorigin-corp/issues/71 but without quickview in the WooCommerce Template Builder which is ok for now.

@AlexGStapleton I want to do a touch more styling. Perhaps remove some spacing in the archive view when using the WooCommerce Template Builder so that the spacing can all be decided from Page Builder. Other than that, I think it's ready for an initial review.