### PR TITLE
Prevent span tags from printing when ! footer text

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -534,6 +534,7 @@ if ( ! function_exists( 'siteorigin_corp_footer_text' ) ) :
  */
 function siteorigin_corp_footer_text() {
 	$text = siteorigin_setting( 'footer_text' );
+	if ( empty( $text ) ) return;
 	$text = str_replace(
 		array( '{sitename}', '{year}' ),
 		array( get_bloginfo( 'sitename' ), date( 'Y' ) ),


### PR DESCRIPTION
The purpose of this PR is to prevent `span` tags from printing when the footer text field is empty. If you'd like to do this another way, let me know.