### PR TITLE
Don’t output breadcrumbs if overlap used

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -40,6 +40,7 @@ if ( ! function_exists( 'siteorigin_corp_breadcrumbs' ) ) :
  * Display's breadcrumbs supported by Yoast SEO & Breadcrumb NavXT.
  */
 function siteorigin_corp_breadcrumbs() {
+	if ( siteorigin_page_setting( 'overlap' ) != 'disabled' ) return;
 	if ( function_exists( 'bcn_display' ) ) {
 		?><div class="breadcrumbs bcn">
 			<?php bcn_display(); ?>


### PR DESCRIPTION
If you're using the page setting header overlap, you can disable the page title but there isn't an easy way to remove breadcrumbs if you have them in use.

If users are making use of the overlap page setting, I suggest that they use Breadcrumb NavXT as it offers a widget which they can insert on overlapped pages.