### PR TITLE
Don’t display the page title if overlap is used

### DIFF
--- a/archive-jetpack-portfolio.php
+++ b/archive-jetpack-portfolio.php
@@ -11,7 +11,7 @@ get_header(); ?>
 
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main">
-			<?php if ( siteorigin_page_setting( 'page_title' ) ) : ?>
+			<?php if ( siteorigin_page_setting( 'page_title' ) && siteorigin_page_setting( 'overlap' ) == 'disabled' ) : ?>
 				<header class="page-header">
 					<?php 
 						the_archive_title( '<h1 class="page-title">', '</h1>' ); 

--- a/archive.php
+++ b/archive.php
@@ -11,7 +11,7 @@ get_header(); ?>
 
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main">
-			<?php if ( siteorigin_page_setting( 'page_title' ) ) : ?>
+			<?php if ( siteorigin_page_setting( 'page_title' ) && siteorigin_page_setting( 'overlap' ) == 'disabled' ) : ?>
 				<header class="page-header">
 					<?php 
 						the_archive_title( '<h1 class="page-title">', '</h1>' ); 

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -17,8 +17,12 @@
 			<?php the_post_thumbnail(); ?>
 		</div>
 	<?php endif; ?>
-	
-	<?php if ( siteorigin_page_setting( 'overlap' ) == 'disabled' || siteorigin_page_setting( 'overlap' ) != 'disabled' && ( has_post_thumbnail() && siteorigin_setting( 'blog_post_featured_image' ) ) ) : ?>
+
+	<?php if (
+		siteorigin_page_setting( 'overlap' ) == 'disabled' ||
+		siteorigin_page_setting( 'overlap' ) != 'disabled' &&
+		( has_post_thumbnail() && siteorigin_setting( 'blog_post_featured_image' ) ) ) :
+	?>
 		<?php if ( siteorigin_page_setting( 'page_title' ) ) : ?>
 			<header class="entry-header">
 				<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -17,11 +17,13 @@
 			<?php the_post_thumbnail(); ?>
 		</div>
 	<?php endif; ?>
-
-	<?php if ( siteorigin_page_setting( 'page_title' ) ) : ?>
-		<header class="entry-header">
-			<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-		</header><!-- .entry-header -->
+	
+	<?php if ( siteorigin_page_setting( 'overlap' ) == 'disabled' || siteorigin_page_setting( 'overlap' ) != 'disabled' && ( has_post_thumbnail() && siteorigin_setting( 'blog_post_featured_image' ) ) ) : ?>
+		<?php if ( siteorigin_page_setting( 'page_title' ) ) : ?>
+			<header class="entry-header">
+				<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+			</header><!-- .entry-header -->
+		<?php endif; ?>
 	<?php endif; ?>
 
 	<div class="entry-content">


### PR DESCRIPTION
Resolves https://github.com/siteorigin/siteorigin-corp/issues/99.

@AlexGStapleton Please, test. Additionally, take a look at `content-page.php` and let me know if there is a preferred way to lay that out. If the featured image is present, we can display the page title, even with overlap as the page title is below the featured image, that's what's happening there.

Thanks