### PR TITLE
Exclude Logo from Jetpack Lazy Load and Smush Lazy Load

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -139,10 +139,7 @@ if (
 		 * Exclude Logo from Lazy Load plugins.
 		 */
 		function siteorigin_corp_lazy_load_exclude( $attr, $attachment ) {
-			$custom_logo_id = siteorigin_setting( 'branding_logo' );
-			if ( empty( $custom_logo_id ) ) {
-				$custom_logo_id = get_theme_mod( 'custom_logo' );
-			}
+			$custom_logo_id = get_theme_mod( 'custom_logo' );
 			if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
 				// Jetpack Lazy Load
 				if ( class_exists( 'Jetpack_Lazy_Images' ) ) {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -129,21 +129,38 @@ function siteorigin_corp_display_retina_logo( $attr, $attachment ) {
 }
 add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_corp_display_retina_logo', 10, 2 );
 
-if ( class_exists( 'LiteSpeed_Cache' ) ) :
-	if ( ! function_exists( 'siteorigin_corp_litespeed_lazy_exclude' ) ) :
+if (
+	class_exists( 'Smush\Core\Modules\Lazy' ) ||
+	class_exists( 'LiteSpeed_Cache' ) ||
+	class_exists( 'Jetpack_Lazy_Images' )
+) :
+	if ( ! function_exists( 'siteorigin_corp_lazy_load_exclude' ) ) :
 		/**
-		 * Exclude Logo from LiteSpeed Cache Lazy Load
+		 * Exclude Logo from Lazy Load plugins.
 		 */
-		function siteorigin_corp_litespeed_lazy_exclude( $attr, $attachment ) {
-			$custom_logo_id = get_theme_mod( 'custom_logo' );
-			if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
-				$attr['data-no-lazy'] = 1;
+		function siteorigin_corp_lazy_load_exclude( $attr, $attachment ) {
+			$custom_logo_id = siteorigin_setting( 'branding_logo' );
+			if ( empty( $custom_logo_id ) ) {
+				$custom_logo_id = get_theme_mod( 'custom_logo' );
 			}
-
+			if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
+				// Jetpack Lazy Load
+				if ( class_exists( 'Jetpack_Lazy_Images' ) ) {
+					$attr['class'] .= ' skip-lazy';
+				}
+				// Smush Lazy Load
+				if ( class_exists( 'Smush\Core\Modules\Lazy' ) ) {
+					$attr['class'] .= ' no-lazyload';
+				}
+				// LiteSpeed Cache Lazy Load
+				if ( class_exists( 'LiteSpeed_Cache' ) ) {
+					$attr['data-no-lazy'] = 1;
+				}
+			}
 			return $attr;
 		}
 	endif;
-	add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_corp_litespeed_lazy_exclude', 10, 2 );
+	add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_corp_lazy_load_exclude', 10, 2 );
 endif;
 
 if ( ! function_exists( 'siteorigin_corp_display_icon' ) ) :


### PR DESCRIPTION
This PR is the Corp version of siteorigin/siteorigin-unwind#260. This PR will ensure the Logo is excluded from Jetpack Lazy Load and Smush Logo. It also merges the previous Lazy Load function into a single function.