### PR TITLE
Feature/menu hover no underline

### DIFF
--- a/header.php
+++ b/header.php
@@ -48,7 +48,7 @@ do_action( 'siteorigin_corp_body_top' );
 					<?php endif ?>
 				</div><!-- .site-branding -->
 
-				<nav id="site-navigation" class="main-navigation">
+				<nav id="site-navigation" class="main-navigation <?php if ( siteorigin_setting( 'navigation_menu_link_hover_underline' ) ) echo ' link-underline' ?>">
 
 					<?php $mega_menu_active = function_exists( 'ubermenu' ) || function_exists( 'max_mega_menu_is_enabled' ) && max_mega_menu_is_enabled( 'menu-1' ); ?>
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -664,10 +664,10 @@ $css .= '/* style */
 	.main-navigation ul .sub-menu li:hover > a,.main-navigation ul .sub-menu li.current_page_item > a,.main-navigation ul .sub-menu li.current-menu-item > a,.main-navigation ul .sub-menu li.current_page_ancestor > a,.main-navigation ul .sub-menu li.current-menu-ancestor > a,.main-navigation ul .children li:hover > a,.main-navigation ul .children li.current_page_item > a,.main-navigation ul .children li.current-menu-item > a,.main-navigation ul .children li.current_page_ancestor > a,.main-navigation ul .children li.current-menu-ancestor > a {
 	color: ${navigation_drop_down_link_hover};
 	}
-	.link-underline ul .sub-menu li:first-of-type {
+	.link-underline.main-navigation ul .sub-menu li:first-of-type {
 	border-top: 2px solid ${navigation_link_accent};
 	}
-	.link-underline ul .children li:first-of-type {
+	.link-underline.main-navigation ul .children li:first-of-type {
 	border-top: 2px solid ${navigation_link_accent};
 	}
 	.main-navigation ul li {

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -107,6 +107,11 @@ function siteorigin_corp_settings_init() {
 					'description' => esc_html__( 'The pixel resolution when the header menu collapses into the mobile menu.', 'siteorigin-corp' ),
 					'live'        => true
 				),
+				'menu_link_hover_underline' => array(
+					'type'        => 'checkbox',
+					'label'       => esc_html__( 'Menu Link Hover Underline', 'siteorigin-corp' ),
+					'description' => esc_html__( 'Underline header menu links on hover.', 'siteorigin-corp' )
+				),
 				'menu_search'     => array(
 					'type'        => 'checkbox',
 					'label'       => esc_html__( 'Menu Search', 'siteorigin-corp' ),
@@ -650,7 +655,7 @@ $css .= '/* style */
 	}
 	a:hover,a:focus,a:active {
 	color: ${typography_text};
-		}
+	}
 	.main-navigation ul .sub-menu li a,.main-navigation ul .children li a {
 	background: ${navigation_drop_down_background};
 	border-color: ${navigation_drop_down_divider};
@@ -659,7 +664,10 @@ $css .= '/* style */
 	.main-navigation ul .sub-menu li:hover > a,.main-navigation ul .sub-menu li.current_page_item > a,.main-navigation ul .sub-menu li.current-menu-item > a,.main-navigation ul .sub-menu li.current_page_ancestor > a,.main-navigation ul .sub-menu li.current-menu-ancestor > a,.main-navigation ul .children li:hover > a,.main-navigation ul .children li.current_page_item > a,.main-navigation ul .children li.current-menu-item > a,.main-navigation ul .children li.current_page_ancestor > a,.main-navigation ul .children li.current-menu-ancestor > a {
 	color: ${navigation_drop_down_link_hover};
 	}
-	.main-navigation ul .sub-menu li:first-of-type,.main-navigation ul .children li:first-of-type {
+	.link-underline ul .sub-menu li:first-of-type {
+	border-top: 2px solid ${navigation_link_accent};
+	}
+	.link-underline ul .children li:first-of-type {
 	border-top: 2px solid ${navigation_link_accent};
 	}
 	.main-navigation ul li {
@@ -674,11 +682,23 @@ $css .= '/* style */
 	#site-navigation.main-navigation ul .menu-button a:hover {
 	background: .rgba( ${typography_accent}, .8);
 	}
-	.main-navigation div > ul:not(.cart_list) > li:hover > a {
+	[class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li:hover > a {
+	color: ${navigation_link_accent};
+	}
+	.link-underline.main-navigation div > ul:not(.cart_list) > li:hover > a {
 	border-color: ${navigation_link_accent};
+	}
+	.main-navigation:not(.link-underline) div > ul:not(.cart_list) > li:hover > a {
+	color: ${navigation_link_accent};
 	}
 	.main-navigation div > ul:not(.cart_list) > li.current > a,.main-navigation div > ul:not(.cart_list) > li.current_page_item > a,.main-navigation div > ul:not(.cart_list) > li.current-menu-item > a,.main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,.main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
 	border-color: ${navigation_link_accent};
+	}
+	:not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current > a,:not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_item > a,:not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-item > a,:not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,:not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
+	color: ${navigation_link_accent};
+	}
+	[class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current > a,[class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_item > a,[class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-item > a,[class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,[class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
+	color: ${navigation_link_accent};
 	}
 	.main-navigation .search-toggle .open svg path {
 	fill: ${navigation_link};
@@ -1361,7 +1381,7 @@ function siteorigin_corp_wc_settings_custom_css( $css ) {
 	ul.cart_list li a:hover,ul.product_list_widget li a:hover {
 	color: ${typography_accent};
 	}
-	ul.cart_list li .amount,ul.cart_list li .quantity,ul.product_list_widget li .amount,ul.product_list_widget li .quantity {
+	ul.cart_list li .amount,ul.cart_list li .quantity,ul.cart_list li .reviewer,ul.product_list_widget li .amount,ul.product_list_widget li .quantity,ul.product_list_widget li .reviewer {
 	color: ${typography_text};
 	}
 	.widget_shopping_cart .cart_list li .remove:hover {
@@ -1639,6 +1659,7 @@ function siteorigin_corp_settings_defaults( $defaults ) {
 	$defaults['navigation_header_menu']               = true;
 	$defaults['navigation_mobile_menu']               = true;
 	$defaults['navigation_mobile_menu_collapse']      = 768;
+	$defaults['navigation_menu_link_hover_underline'] = true;
 	$defaults['navigation_menu_search']               = true;
 	$defaults['navigation_post']                      = true;
 	$defaults['navigation_scroll_to_top']             = true;

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -62,11 +62,11 @@
 					left: 100%;
 				}
 
-				@at-root .link-underline ul .sub-menu li:first-of-type {
+				@at-root .link-underline.main-navigation ul .sub-menu li:first-of-type {
 					border-top: 2px solid $color__navigation_link_accent;
 				}
 
-				@at-root .link-underline ul .children li:first-of-type {
+				@at-root .link-underline.main-navigation ul .children li:first-of-type {
 					border-top: 2px solid $color__navigation_link_accent;
 				}
 

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -62,7 +62,11 @@
 					left: 100%;
 				}
 
-				&:first-of-type {
+				@at-root .link-underline ul .sub-menu li:first-of-type {
+					border-top: 2px solid $color__navigation_link_accent;
+				}
+
+				@at-root .link-underline ul .children li:first-of-type {
 					border-top: 2px solid $color__navigation_link_accent;
 				}
 
@@ -106,7 +110,6 @@
 			}
 
 			a {
-				border-bottom: 2px solid transparent;
 				color: $color__navigation-link;
 				display: block;
 				font-weight: bold;
@@ -189,7 +192,6 @@
 	// First level items.
 	div > ul:not(.cart_list) > li {
 
-		// Overlap.
 		.overlap-light .site-header:not(.stuck) & > a {
 			color: #fff;
 		}
@@ -198,9 +200,21 @@
 			color: #2d2d2d;
 		}
 
-		&:hover > a {
+		@at-root [class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li:hover > a {
+			color: $color__navigation_link_accent;
+		}
+
+		@at-root .link-underline#{&} > a {
+			border-bottom: 2px solid transparent;
+		}
+
+		@at-root .link-underline#{&}:hover > a {
 			border-bottom: 2px solid;
 			border-color: $color__navigation_link_accent;
+		}
+
+		@at-root .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li:hover > a {
+			color: $color__navigation_link_accent;
 		}
 
 		&:not(.current-menu-item).menu-item-has-children:not(.current_page_ancestor):not(.current-menu-ancestor) > a {
@@ -213,6 +227,28 @@
 		&.current_page_ancestor > a,
 		&.current-menu-ancestor > a {
 			border-color: $color__navigation_link_accent;
+		}
+
+		@at-root :not(.link-underline)#{&} {
+
+			&.current > a,
+			&.current_page_item > a,
+			&.current-menu-item > a,
+			&.current_page_ancestor > a,
+			&.current-menu-ancestor > a {
+				color: $color__navigation_link_accent;
+			}
+		}
+
+		@at-root [class*="overlap"] :not(.link-underline)#{&} {
+
+			&.current > a,
+			&.current_page_item > a,
+			&.current-menu-item > a,
+			&.current_page_ancestor > a,
+			&.current-menu-ancestor > a {
+				color: $color__navigation_link_accent;
+			}
 		}
 	}
 

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -229,7 +229,7 @@
 			border-color: $color__navigation_link_accent;
 		}
 
-		@at-root :not(.link-underline)#{&} {
+		@at-root .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li {
 
 			&.current > a,
 			&.current_page_item > a,
@@ -240,7 +240,7 @@
 			}
 		}
 
-		@at-root [class*="overlap"] :not(.link-underline)#{&} {
+		@at-root [class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li {
 
 			&.current > a,
 			&.current_page_item > a,

--- a/style.css
+++ b/style.css
@@ -579,9 +579,9 @@ a {
         .main-navigation ul .children li:hover > ul,
         .main-navigation ul .children li.focus > ul {
           left: 100%; }
-        .link-underline ul .sub-menu li:first-of-type {
+        .link-underline.main-navigation ul .sub-menu li:first-of-type {
           border-top: 2px solid #f14e4e; }
-        .link-underline ul .children li:first-of-type {
+        .link-underline.main-navigation ul .children li:first-of-type {
           border-top: 2px solid #f14e4e; }
         .main-navigation ul .sub-menu li:last-of-type > a,
         .main-navigation ul .children li:last-of-type > a {

--- a/style.css
+++ b/style.css
@@ -579,8 +579,9 @@ a {
         .main-navigation ul .children li:hover > ul,
         .main-navigation ul .children li.focus > ul {
           left: 100%; }
-        .main-navigation ul .sub-menu li:first-of-type,
-        .main-navigation ul .children li:first-of-type {
+        .link-underline ul .sub-menu li:first-of-type {
+          border-top: 2px solid #f14e4e; }
+        .link-underline ul .children li:first-of-type {
           border-top: 2px solid #f14e4e; }
         .main-navigation ul .sub-menu li:last-of-type > a,
         .main-navigation ul .children li:last-of-type > a {
@@ -607,7 +608,6 @@ a {
       .main-navigation ul li:last-of-type {
         margin-right: 0; }
       .main-navigation ul li a {
-        border-bottom: 2px solid transparent;
         color: #2d2d2d;
         display: block;
         font-weight: bold;
@@ -661,9 +661,15 @@ a {
     color: #fff; }
   .overlap-dark .site-header:not(.stuck) .main-navigation div > ul:not(.cart_list) > li > a {
     color: #2d2d2d; }
-  .main-navigation div > ul:not(.cart_list) > li:hover > a {
+  [class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li:hover > a {
+    color: #f14e4e; }
+  .link-underline.main-navigation div > ul:not(.cart_list) > li > a {
+    border-bottom: 2px solid transparent; }
+  .link-underline.main-navigation div > ul:not(.cart_list) > li:hover > a {
     border-bottom: 2px solid;
     border-color: #f14e4e; }
+  .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li:hover > a {
+    color: #f14e4e; }
   .main-navigation div > ul:not(.cart_list) > li:not(.current-menu-item).menu-item-has-children:not(.current_page_ancestor):not(.current-menu-ancestor) > a {
     border-bottom: none; }
   .main-navigation div > ul:not(.cart_list) > li.current > a,
@@ -672,6 +678,18 @@ a {
   .main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,
   .main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
     border-color: #f14e4e; }
+  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current > a,
+  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_item > a,
+  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-item > a,
+  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,
+  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
+    color: #f14e4e; }
+  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current > a,
+  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_item > a,
+  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-item > a,
+  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,
+  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
+    color: #f14e4e; }
   .main-navigation .search-toggle {
     background: transparent;
     border: none;
@@ -3122,5 +3140,3 @@ object {
             font-size: 26px; } }
         .featured-posts-slider .slides .slide .slide-content .entry-title a {
           color: #fff; }
-
-/*# sourceMappingURL=sass/maps/style.css.map */

--- a/style.css
+++ b/style.css
@@ -678,17 +678,17 @@ a {
   .main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,
   .main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
     border-color: #f14e4e; }
-  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current > a,
-  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_item > a,
-  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-item > a,
-  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,
-  :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
+  .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current > a,
+  .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current_page_item > a,
+  .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current-menu-item > a,
+  .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current_page_ancestor > a,
+  .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current-menu-ancestor > a {
     color: #f14e4e; }
-  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current > a,
-  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_item > a,
-  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-item > a,
-  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current_page_ancestor > a,
-  [class*="overlap"] :not(.link-underline).main-navigation div > ul:not(.cart_list) > li.current-menu-ancestor > a {
+  [class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current > a,
+  [class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current_page_item > a,
+  [class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current-menu-item > a,
+  [class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current_page_ancestor > a,
+  [class*="overlap"] .main-navigation:not(.link-underline) div > ul:not(.cart_list) > li.current-menu-ancestor > a {
     color: #f14e4e; }
   .main-navigation .search-toggle {
     background: transparent;


### PR DESCRIPTION
There are many designs that would benefit from using a regular menu hover vs the current underline. The underline works better with light background headers IMO.

**Functionality**

There is a lot to test with this addition.

- Normal hover
- Current menu item: check that parent and current sub-menu is still working.
- Check that hover and current menu items work when overlap, overlap light and overlap dark is used.
- Check that the current menu indication works with the one-page functionality.

Ideally, the above needs to be tested with a custom accent color used. The above needs to be tested using the default menu hover underline to ensure nothing has been broken and then with the new setting disabled.

**Code**

I'm not quite sure how to improve https://github.com/siteorigin/siteorigin-corp/compare/feature/menu-hover-no-underline?expand=1#diff-a0d34fb91a5f972fb94a85de774e69afR65-R69.

We could use:

```
@at-root #{selector-append(".link-underline", &)} {
	border-top: 2px solid $color__navigation_link_accent;
}
```

But I don't know how to add on `:first-of-type` to the above.
Ref: https://github.com/sass/sass/issues/2135.

--

Anything else you notice, functionality or code related, anything that can be better laid our optimised, let me know.