### PR TITLE
SO Premium WooCommerce Template Builder Checkout Layout Fix

### DIFF
--- a/sass/woocommerce/_checkout.scss
+++ b/sass/woocommerce/_checkout.scss
@@ -129,6 +129,7 @@ form.checkout > .blockUI {
 		}
 	}
 
+	// Order review section in SO WC Template Builder.
 	.panel-grid-cell #order_review {
 		clear: none;
 		float: none;

--- a/sass/woocommerce/_checkout.scss
+++ b/sass/woocommerce/_checkout.scss
@@ -129,16 +129,10 @@ form.checkout > .blockUI {
 		}
 	}
 
-	// Order review heading in SO WC Template Builder.
-	.panel-grid-cell #order_review_heading {
-		clear: right;
-		float: right;
-		width: 48%;
-
-		@media (max-width: 768px) {
-			padding: 0 20px;
-			width: 100%;
-		}
+	.panel-grid-cell #order_review {
+		clear: none;
+		float: none;
+		width: 100%;
 	}
 
 	.woocommerce-checkout-review-order {

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1739,14 +1739,10 @@ form.checkout > .blockUI {
       list-style: none;
       margin: 0; }
 
-.woocommerce .panel-grid-cell #order_review_heading {
-  clear: right;
-  float: right;
-  width: 48%; }
-  @media (max-width: 768px) {
-    .woocommerce .panel-grid-cell #order_review_heading {
-      padding: 0 20px;
-      width: 100%; } }
+.woocommerce .panel-grid-cell #order_review {
+  clear: none;
+  float: none;
+  width: 100%; }
 
 .woocommerce .woocommerce-checkout-review-order {
   background: #fff;


### PR DESCRIPTION
This PR should be tested with https://github.com/siteorigin/siteorigin-premium/pull/395. This PR will change the Checkout page layout but is necessary to accurately reflect the Page Builder layout as presented in the admin. If any users would prefer the layout as it was we can assist with Custom CSS.