### PR TITLE
Moved excerpt variable into related conditional

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -290,9 +290,8 @@ function siteorigin_corp_excerpt() {
 		$length = siteorigin_setting( 'blog_excerpt_length' );
 	}
 
-	$excerpt = explode( ' ', get_the_excerpt(), $length );
-
 	if ( $length ) {
+		$excerpt = explode( ' ', get_the_excerpt(), $length );
 		if ( count( $excerpt ) >= $length ) {
 			array_pop( $excerpt );
 			$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>' . $read_more_text;


### PR DESCRIPTION
If the excerpt word length field is empty, the following warning is triggered:

`Warning: explode() expects parameter 3 to be int, string given in /siteorigin/wp-content/themes/siteorigin-corp/inc/template-tags.php on line 293`

This PR resolves that warning. To recreate the issue, clear the excerpt length setting field.