### PR TITLE
Set excerpt count if setting empty

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -20,7 +20,7 @@ endif;
 if ( ! function_exists( 'siteorigin_corp_excerpt_more' ) ) :
 /**
  * Add a more link to the excerpt.
- * @deprecated 1.4.3 Use siteorigin_corp_excerpt() 
+ * @deprecated 1.4.3 Use siteorigin_corp_excerpt()
  */
 function siteorigin_corp_excerpt_more( $more ) {
 	if ( is_search() ) return;

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -6,16 +6,6 @@
  * @license GPL 2.0
  */
 
-if ( ! function_exists( 'siteorigin_corp_excerpt_length' ) ) :
-/**
- * Filter the excerpt length.
- * @deprecated 1.4.3 Use siteorigin_corp_excerpt()
- */
-function siteorigin_corp_excerpt_length( $length ) {
-	return siteorigin_setting( 'blog_excerpt_length' );
-}
-endif;
-
 if ( ! function_exists( 'siteorigin_corp_excerpt_more' ) ) :
 /**
  * Add a more link to the excerpt.

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -6,6 +6,16 @@
  * @license GPL 2.0
  */
 
+if ( ! function_exists( 'siteorigin_corp_excerpt_length' ) ) :
+/**
+ * Filter the excerpt length.
+ * @deprecated 1.4.3 Use siteorigin_corp_excerpt()
+ */
+function siteorigin_corp_excerpt_length( $length ) {
+	return siteorigin_setting( 'blog_excerpt_length' );
+}
+endif;
+
 if ( ! function_exists( 'siteorigin_corp_excerpt_more' ) ) :
 /**
  * Add a more link to the excerpt.

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -14,7 +14,6 @@ if ( ! function_exists( 'siteorigin_corp_excerpt_length' ) ) :
 function siteorigin_corp_excerpt_length( $length ) {
 	return siteorigin_setting( 'blog_excerpt_length' );
 }
-add_filter( 'excerpt_length', 'siteorigin_corp_excerpt_length', 10 );
 endif;
 
 if ( ! function_exists( 'siteorigin_corp_excerpt_more' ) ) :
@@ -30,7 +29,6 @@ function siteorigin_corp_excerpt_more( $more ) {
 	}
 }
 endif;
-add_filter( 'excerpt_more', 'siteorigin_corp_excerpt_more' );
 
 if ( ! function_exists( 'siteorigin_corp_woocommerce_archive_product_image_buttons' ) ) :
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -269,6 +269,16 @@ function siteorigin_corp_read_more_link() {
 endif;
 add_filter( 'the_content_more_link', 'siteorigin_corp_read_more_link' );
 
+if ( ! function_exists( 'siteorigin_corp_excerpt_length' ) ) :
+/**
+ * Filter the excerpt length.
+ */
+function siteorigin_corp_excerpt_length( $length ) {
+	return siteorigin_setting( 'blog_excerpt_length' );
+}
+add_filter( 'excerpt_length', 'siteorigin_corp_excerpt_length', 10 );
+endif;
+
 if ( ! function_exists( 'siteorigin_corp_excerpt' ) ) :
 /**
  * Outputs the excerpt.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -298,20 +298,15 @@ function siteorigin_corp_excerpt() {
 	}
 
 	$ellipsis = '...';
-	$excerpt = explode( ' ', get_the_content(), $length );
+	$excerpt = explode( ' ', get_the_excerpt(), $length );
 
-	// If there is a custom excerpt, don't apply the Excerpt Length setting but do still apply the Post Excerpt Read More Link setting.
-	if ( has_excerpt() ) {
-		$excerpt = '<p>' . get_the_excerpt() . '</p>' . $read_more_text;
+	// If the auto excerpt is longer than the Excerpt Length and there isn't a custom excerpt provided, add the $ellipsis.
+	if ( ! has_excerpt() && count( $excerpt ) >= $length ) {
+		array_pop( $excerpt );
+		$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>' . $read_more_text;
+	// If the auto excerpt isn't longer than the Excerpt Length, don't add the $ellipsis.
 	} else {
-		// If the auto excerpt is longer than the Excerpt Length, add the $ellipsis.
-		if ( count( $excerpt ) >= $length ) {
-			array_pop( $excerpt );
-			$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>' . $read_more_text;
-		// If the auto excerpt isn't longer than the Excerpt Length, don't add the $ellipsis.
-		} else {
-			$excerpt = '<p>' . implode( " ", $excerpt ) . '</p>' . $read_more_text;
-		}
+		$excerpt = '<p>' . implode( " ", $excerpt ) . '</p>' . $read_more_text;
 	}
 
 	$excerpt = preg_replace( '`\s\[[^\]]*\]`','', $excerpt );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -281,7 +281,11 @@ function siteorigin_corp_excerpt() {
 		$read_more_text = '';
 	}
 
-	$length = is_search() ? 30 : siteorigin_setting( 'blog_excerpt_length', 55 );
+	if ( is_search() ) {
+		$length = 30;
+	} else {
+		$length = ! empty( siteorigin_setting( 'blog_excerpt_length' ) ) ? siteorigin_setting( 'blog_excerpt_length' ) : 55;
+	}
 
 	$excerpt = get_the_excerpt();
 	$excerpt_add_read_more = str_word_count( $excerpt ) >= $length;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -289,7 +289,7 @@ function siteorigin_corp_excerpt() {
 
 	$excerpt = get_the_excerpt();
 	$excerpt_add_read_more = str_word_count( $excerpt ) >= $length;
-	wp_trim_words( $excerpt, $length, '...' );
+	$excerpt = wp_trim_words( $excerpt, $length, '...' );
 
 	if ( ! empty( $read_more_text ) && ( has_excerpt() || $excerpt_add_read_more ) ) {
 		$excerpt .= $read_more_text;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -274,7 +274,6 @@ if ( ! function_exists( 'siteorigin_corp_excerpt' ) ) :
  * Outputs the excerpt.
  */
 function siteorigin_corp_excerpt() {
-
 	if ( ( siteorigin_setting( 'blog_archive_content' ) == 'excerpt' ) && siteorigin_setting( 'blog_post_excerpt_read_more_link', true ) && ! is_search() ) {
 		$read_more_text = esc_html__( 'Continue reading', 'siteorigin-corp' );
 		$read_more_text = '<a class="more-link excerpt" href="' . esc_url( get_permalink() ) . '"><span class="more-text">' . $read_more_text . ' <span class="icon-long-arrow-right"></span></span></a>';
@@ -283,27 +282,31 @@ function siteorigin_corp_excerpt() {
 	}
 
 	if ( is_search() ) {
-		$ellipsis = '...';
-		$length = 38;
+		$length = 30;
 	} else {
-		$ellipsis = '...';
 		$length = ! empty( siteorigin_setting( 'blog_excerpt_length' ) ) ? siteorigin_setting( 'blog_excerpt_length' ) : 55;
 	}
 
-	if ( $length ) {
-		$excerpt = explode( ' ', get_the_excerpt(), $length );
+	$ellipsis = '...';
+	$excerpt = explode( ' ', get_the_content(), $length );
+
+	// If there is a custom excerpt, don't apply the Excerpt Length setting but do still apply the Post Excerpt Read More Link setting.
+	if ( has_excerpt() ) {
+		$excerpt = '<p>' . get_the_excerpt() . '</p>' . $read_more_text;
+	} else {
+		// If the auto excerpt is longer than the Excerpt Length, add the $ellipsis.
 		if ( count( $excerpt ) >= $length ) {
 			array_pop( $excerpt );
 			$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>' . $read_more_text;
+		// If the auto excerpt isn't longer than the Excerpt Length, don't add the $ellipsis.
 		} else {
-			$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>' . $read_more_text;
+			$excerpt = '<p>' . implode( " ", $excerpt ) . '</p>' . $read_more_text;
 		}
 	}
 
-	$excerpt = preg_replace( '`\[[^\]]*\]`','', $excerpt );
+	$excerpt = preg_replace( '`\s\[[^\]]*\]`','', $excerpt );
 
 	echo $excerpt;
-
 }
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -287,7 +287,7 @@ function siteorigin_corp_excerpt() {
 		$length = 38;
 	} else {
 		$ellipsis = '...';
-		$length = siteorigin_setting( 'blog_excerpt_length' );
+		$length = ! empty( siteorigin_setting( 'blog_excerpt_length' ) ) ? siteorigin_setting( 'blog_excerpt_length' ) : 55;
 	}
 
 	if ( $length ) {
@@ -298,8 +298,6 @@ function siteorigin_corp_excerpt() {
 		} else {
 			$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>' . $read_more_text;
 		}
-	} else {
-		$excerpt = get_the_excerpt();
 	}
 
 	$excerpt = preg_replace( '`\[[^\]]*\]`','', $excerpt );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -269,16 +269,6 @@ function siteorigin_corp_read_more_link() {
 endif;
 add_filter( 'the_content_more_link', 'siteorigin_corp_read_more_link' );
 
-if ( ! function_exists( 'siteorigin_corp_excerpt_length' ) ) :
-/**
- * Filter the excerpt length.
- */
-function siteorigin_corp_excerpt_length( $length ) {
-	return siteorigin_setting( 'blog_excerpt_length' );
-}
-add_filter( 'excerpt_length', 'siteorigin_corp_excerpt_length', 10 );
-endif;
-
 if ( ! function_exists( 'siteorigin_corp_excerpt' ) ) :
 /**
  * Outputs the excerpt.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -291,25 +291,15 @@ function siteorigin_corp_excerpt() {
 		$read_more_text = '';
 	}
 
-	if ( is_search() ) {
-		$length = 30;
-	} else {
-		$length = ! empty( siteorigin_setting( 'blog_excerpt_length' ) ) ? siteorigin_setting( 'blog_excerpt_length' ) : 55;
+	$length = is_search() ? 30 : siteorigin_setting( 'blog_excerpt_length', 55 );
+
+	$excerpt = get_the_excerpt();
+	$excerpt_add_read_more = str_word_count( $excerpt ) >= $length;
+	wp_trim_words( $excerpt, $length, '...' );
+
+	if ( ! empty( $read_more_text ) && ( has_excerpt() || $excerpt_add_read_more ) ) {
+		$excerpt .= $read_more_text;
 	}
-
-	$ellipsis = '...';
-	$excerpt = explode( ' ', get_the_excerpt(), $length );
-
-	// If the auto excerpt is longer than the Excerpt Length and there isn't a custom excerpt provided, add the $ellipsis.
-	if ( ! has_excerpt() && count( $excerpt ) >= $length ) {
-		array_pop( $excerpt );
-		$excerpt = '<p>' . implode( " ", $excerpt ) . $ellipsis . '</p>' . $read_more_text;
-	// If the auto excerpt isn't longer than the Excerpt Length, don't add the $ellipsis.
-	} else {
-		$excerpt = '<p>' . implode( " ", $excerpt ) . '</p>' . $read_more_text;
-	}
-
-	$excerpt = preg_replace( '`\s\[[^\]]*\]`','', $excerpt );
 
 	echo $excerpt;
 }


### PR DESCRIPTION
This PR will set the excerpt word count to 55 if the field is empty. 

@AlexGStapleton The filters in the deprecated file were interfering. 

Can you spot why if the excerpt count is set over 55 there is a space before the ellipsis but if the count is 55 or under, there is no space before the ellipsis?