### PR TITLE
Lazy load 5.5 update

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -172,16 +172,3 @@ function siteorigin_corp_jetpackme_remove_rp() {
 }
 endif;
 add_filter( 'wp', 'siteorigin_corp_jetpackme_remove_rp', 20 );
-
-// If Jetpack Lazy Images is enabled, prevent the logo from being affected.
-if ( Jetpack::is_module_active( 'lazy-images' ) ) :
-	if ( ! function_exists( 'siteorigin_corp_jetpack_logo_not_lazy' ) ) {
-
-		function siteorigin_corp_jetpack_logo_not_lazy( $blacklisted_classes ) {
-			$blacklisted_classes[] = 'custom-logo';
-
-			return $blacklisted_classes;
-		}
-		add_filter( 'jetpack_lazy_images_blacklisted_classes', 'siteorigin_corp_jetpack_logo_not_lazy' );
-	}
-endif;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -129,36 +129,35 @@ function siteorigin_corp_display_retina_logo( $attr, $attachment ) {
 }
 add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_corp_display_retina_logo', 10, 2 );
 
-if (
-	class_exists( 'Smush\Core\Modules\Lazy' ) ||
-	class_exists( 'LiteSpeed_Cache' ) ||
-	class_exists( 'Jetpack_Lazy_Images' )
-) :
-	if ( ! function_exists( 'siteorigin_corp_lazy_load_exclude' ) ) :
-		/**
-		 * Exclude Logo from Lazy Load plugins.
-		 */
-		function siteorigin_corp_lazy_load_exclude( $attr, $attachment ) {
+if ( ! function_exists( 'siteorigin_corp_lazy_load_exclude' ) ) :
+	/**
+	 * Exclude Logo from Lazy Load plugins.
+	 */
+	function siteorigin_corp_lazy_load_exclude( $attr, $attachment ) {
+		$custom_logo_id = siteorigin_setting( 'branding_logo' );
+		if ( empty( $custom_logo_id ) ) {
 			$custom_logo_id = get_theme_mod( 'custom_logo' );
-			if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
-				// Jetpack Lazy Load
-				if ( class_exists( 'Jetpack_Lazy_Images' ) ) {
-					$attr['class'] .= ' skip-lazy';
-				}
-				// Smush Lazy Load
-				if ( class_exists( 'Smush\Core\Modules\Lazy' ) ) {
-					$attr['class'] .= ' no-lazyload';
-				}
-				// LiteSpeed Cache Lazy Load
-				if ( class_exists( 'LiteSpeed_Cache' ) ) {
-					$attr['data-no-lazy'] = 1;
-				}
-			}
-			return $attr;
 		}
-	endif;
-	add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_corp_lazy_load_exclude', 10, 2 );
+		if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
+			// Jetpack Lazy Load
+			if ( class_exists( 'Jetpack_Lazy_Images' ) ) {
+				$attr['class'] .= ' skip-lazy';
+			}
+			// Smush Lazy Load
+			if ( class_exists( 'Smush\Core\Modules\Lazy' ) ) {
+				$attr['class'] .= ' no-lazyload';
+			}
+			// LiteSpeed Cache Lazy Load
+			if ( class_exists( 'LiteSpeed_Cache' ) || class_exists( 'LiteSpeed\Media' ) ) {
+				$attr['data-no-lazy'] = 1;
+			}
+			// WP 5.5
+			$attr['loading'] = false;
+		}
+		return $attr;
+	}
 endif;
+add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_corp_lazy_load_exclude', 10, 2 );
 
 if ( ! function_exists( 'siteorigin_corp_display_icon' ) ) :
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -140,7 +140,7 @@ if ( ! function_exists( 'siteorigin_corp_lazy_load_exclude' ) ) :
 		}
 		if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
 			// Jetpack Lazy Load
-			if ( class_exists( 'Jetpack_Lazy_Images' ) ) {
+			if ( class_exists( 'Jetpack_Lazy_Images' ) || class_exists( 'Automattic\\Jetpack\\Jetpack_Lazy_Images' ) ) {
 				$attr['class'] .= ' skip-lazy';
 			}
 			// Smush Lazy Load


### PR DESCRIPTION
https://github.com/siteorigin/siteorigin-north/pull/397

- Removed legacy Jetpack Lazy Load code
- Includes WP 5.5 Lazyload
- Restored LiteSpeed Lazy Load Compatibility