### PR TITLE
Lazy Load Logo Exclude: Set loading to eager

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -152,7 +152,7 @@ if ( ! function_exists( 'siteorigin_corp_lazy_load_exclude' ) ) :
 				$attr['data-no-lazy'] = 1;
 			}
 			// WP 5.5
-			$attr['loading'] = false;
+			$attr['loading'] = 'eager';
 		}
 		return $attr;
 	}


### PR DESCRIPTION
This PR will ensure we comply with HTML standards with how we're disabling (lazy) loading for the Slider images.