### PR TITLE
Lazy Load Logo Exclude: Don't check for logo setting

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1823,3 +1823,4 @@ add_filter( 'siteorigin_about_page', 'siteorigin_corp_about_page_sections' );
 
 // Exclude theme logo from Lazy Loading.
 add_filter( 'siteorigin_settings_lazy_load_exclude_logo', '__return_true' );
+add_filter( 'siteorigin_settings_lazy_load_exclude_logo_setting', '__return_false' );


### PR DESCRIPTION
Requires https://github.com/siteorigin/settings/pull/67

This PR tells the settings framework not to use any setting for the theme logo and instead to only use the WordPress Custom Logo.