### PR TITLE
Quick View: Restrict Image Height

### DIFF
--- a/sass/woocommerce/_quick-view.scss
+++ b/sass/woocommerce/_quick-view.scss
@@ -71,7 +71,7 @@
 				}
 
 				.slide {
-					background: #2d2d2d;
+					background: #fff;
 					text-align: center;
 				}
 			}

--- a/sass/woocommerce/_quick-view.scss
+++ b/sass/woocommerce/_quick-view.scss
@@ -54,8 +54,6 @@
 			float: left;
 			padding: 20px 15px 20px 20px;
 			width: 50%;
-			max-height: 555px;
-			overflow: hidden;
 
 			img {
 				height: auto;
@@ -64,8 +62,17 @@
 				vertical-align: middle;
 			}
 
-			.slide {
-				text-align: center;
+			.flexslider {
+				background: transparent;
+				.flex-viewport {
+					max-height: 555px;
+					overflow: hidden;
+				}
+
+				.slide {
+					text-align: center;
+					background: #2d2d2d;
+				}
 			}
 
 			@media (max-width: 768px) {

--- a/sass/woocommerce/_quick-view.scss
+++ b/sass/woocommerce/_quick-view.scss
@@ -71,7 +71,6 @@
 				}
 
 				.slide {
-					background: #fff;
 					text-align: center;
 				}
 			}

--- a/sass/woocommerce/_quick-view.scss
+++ b/sass/woocommerce/_quick-view.scss
@@ -54,11 +54,18 @@
 			float: left;
 			padding: 20px 15px 20px 20px;
 			width: 50%;
+			max-height: 555px;
+			overflow: hidden;
 
 			img {
 				height: auto;
 				max-width: 100%;
+				width: auto;
 				vertical-align: middle;
+			}
+
+			.slide {
+				text-align: center;
 			}
 
 			@media (max-width: 768px) {

--- a/sass/woocommerce/_quick-view.scss
+++ b/sass/woocommerce/_quick-view.scss
@@ -65,7 +65,7 @@
 			.flexslider {
 				background: transparent;
 				.flex-viewport {
-					max-height: 555px;
+					max-height: 535px;
 					overflow: hidden;
 				}
 

--- a/sass/woocommerce/_quick-view.scss
+++ b/sass/woocommerce/_quick-view.scss
@@ -58,20 +58,21 @@
 			img {
 				height: auto;
 				max-width: 100%;
-				width: auto;
 				vertical-align: middle;
+				width: auto;
 			}
 
 			.flexslider {
 				background: transparent;
+
 				.flex-viewport {
 					max-height: 535px;
 					overflow: hidden;
 				}
 
 				.slide {
-					text-align: center;
 					background: #2d2d2d;
+					text-align: center;
 				}
 			}
 

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1048,7 +1048,7 @@ input.button.added:after,
     #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider {
       background: transparent; }
       #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider .flex-viewport {
-        max-height: 555px;
+        max-height: 535px;
         overflow: hidden; }
       #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider .slide {
         text-align: center;

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1039,16 +1039,20 @@ input.button.added:after,
   #quick-view-container .product-content-wrapper .product-image-wrapper {
     float: left;
     padding: 20px 15px 20px 20px;
-    width: 50%;
-    max-height: 555px;
-    overflow: hidden; }
+    width: 50%; }
     #quick-view-container .product-content-wrapper .product-image-wrapper img {
       height: auto;
       max-width: 100%;
       width: auto;
       vertical-align: middle; }
-    #quick-view-container .product-content-wrapper .product-image-wrapper .slide {
-      text-align: center; }
+    #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider {
+      background: transparent; }
+      #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider .flex-viewport {
+        max-height: 555px;
+        overflow: hidden; }
+      #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider .slide {
+        text-align: center;
+        background: #2d2d2d; }
     @media (max-width: 768px) {
       #quick-view-container .product-content-wrapper .product-image-wrapper {
         float: none;

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1043,16 +1043,16 @@ input.button.added:after,
     #quick-view-container .product-content-wrapper .product-image-wrapper img {
       height: auto;
       max-width: 100%;
-      width: auto;
-      vertical-align: middle; }
+      vertical-align: middle;
+      width: auto; }
     #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider {
       background: transparent; }
       #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider .flex-viewport {
         max-height: 535px;
         overflow: hidden; }
       #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider .slide {
-        text-align: center;
-        background: #2d2d2d; }
+        background: #2d2d2d;
+        text-align: center; }
     @media (max-width: 768px) {
       #quick-view-container .product-content-wrapper .product-image-wrapper {
         float: none;

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1039,11 +1039,16 @@ input.button.added:after,
   #quick-view-container .product-content-wrapper .product-image-wrapper {
     float: left;
     padding: 20px 15px 20px 20px;
-    width: 50%; }
+    width: 50%;
+    max-height: 555px;
+    overflow: hidden; }
     #quick-view-container .product-content-wrapper .product-image-wrapper img {
       height: auto;
       max-width: 100%;
+      width: auto;
       vertical-align: middle; }
+    #quick-view-container .product-content-wrapper .product-image-wrapper .slide {
+      text-align: center; }
     @media (max-width: 768px) {
       #quick-view-container .product-content-wrapper .product-image-wrapper {
         float: none;

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1051,7 +1051,7 @@ input.button.added:after,
         max-height: 535px;
         overflow: hidden; }
       #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider .slide {
-        background: #2d2d2d;
+        background: #fff;
         text-align: center; }
     @media (max-width: 768px) {
       #quick-view-container .product-content-wrapper .product-image-wrapper {

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1051,7 +1051,6 @@ input.button.added:after,
         max-height: 535px;
         overflow: hidden; }
       #quick-view-container .product-content-wrapper .product-image-wrapper .flexslider .slide {
-        background: #fff;
         text-align: center; }
     @media (max-width: 768px) {
       #quick-view-container .product-content-wrapper .product-image-wrapper {


### PR DESCRIPTION
This PR restricts the height of images shown in the Quick View. [Here's a video of what it previously looked like](https://drive.google.com/uc?id=1jJmmPwWYPRm939Fn9Od-X6LWCVKInVts), and [here's a video of how it looks now](https://drive.google.com/uc?id=1YekO_H48tDG1iYyl-QO4u5ZNWi4zo0Ee).

