### PR TITLE
Further Excerpt changes

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -277,7 +277,7 @@ function siteorigin_corp_excerpt() {
 		$excerpt .= $read_more_text;
 	}
 
-	echo $excerpt;
+	echo '<p>' . wp_kses_post( $excerpt ) . '</p>';
 }
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -268,7 +268,10 @@ function siteorigin_corp_excerpt() {
 
 	$excerpt = get_the_excerpt();
 	$excerpt_add_read_more = str_word_count( $excerpt ) >= $length;
-	$excerpt = wp_trim_words( $excerpt, $length, '...' );
+
+	if ( ! has_excerpt() ) {
+		$excerpt = wp_trim_words( $excerpt, $length, '...' );
+	}
 
 	if ( ! empty( $read_more_text ) && ( has_excerpt() || $excerpt_add_read_more ) ) {
 		$excerpt .= $read_more_text;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -243,7 +243,7 @@ if ( ! function_exists( 'siteorigin_corp_excerpt_length' ) ) :
  * Filter the excerpt length.
  */
 function siteorigin_corp_excerpt_length( $length ) {
-	return siteorigin_setting( 'blog_excerpt_length' );
+	return ! empty( siteorigin_setting( 'blog_excerpt_length' ) ) ? siteorigin_setting( 'blog_excerpt_length' ) : 55;
 }
 add_filter( 'excerpt_length', 'siteorigin_corp_excerpt_length', 10 );
 endif;


### PR DESCRIPTION
This PR alters how excerpts are handled and is a follow up to https://github.com/siteorigin/siteorigin-corp/pull/128
Changes made:

- If excerpt length is empty, the excerpt length will default to 55
- Manual excerpts aren't trimmed for length.
- Nest and escaped excerpt