### PR TITLE
Apply header_margin to header and sentinel

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -900,8 +900,10 @@ $css .= '/* style */
 	.site-header {
 	background: ${header_background};
 	border-bottom: 1px solid ${header_border};
-	margin-bottom: ${header_margin};
 	padding: ${header_padding} 0;
+	}
+	.site-header,.masthead-sentinel {
+		margin-bottom: ${header_margin};
 	}
 	.site-header .site-branding .site-title {
 	.font( ${typography_site_title_font} );


### PR DESCRIPTION
This moves this setting in line with how it's handled in North and also allows users to completely globally remove the margin if the user wanted.

Currently, if the Sticky Header is enabled, and you set the Header Bottom Margin to a value lower than 30px, nothing will happen. This PR fixes that. If the Sticky Header is disabled, it worked as expected. 