### PR TITLE
Add `siteorigin_corp_display_mini_cart` filter

### DIFF
--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -85,8 +85,12 @@ if ( ! function_exists( 'siteorigin_corp_woocommerce_mini_cart' ) ) :
  * Display the WooCommerce mini cart.
  */
 function siteorigin_corp_woocommerce_mini_cart() {
-	if ( class_exists( 'Woocommerce' ) && ! ( is_cart() || is_checkout() ) ) : ?>
-		<?php global $woocommerce; ?>
+	if (
+		class_exists( 'Woocommerce' ) &&
+		apply_filters( 'siteorigin_corp_display_mini_cart', ! ( is_cart() || is_checkout() ) )
+	) :
+		global $woocommerce;
+		?>
 		<ul class="shopping-cart">
 			<li>
 				<a class="shopping-cart-link" href="<?php echo esc_url( wc_get_cart_url() ); ?>" title="<?php esc_attr_e( 'View shopping cart', 'siteorigin-corp' ); ?>">


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-corp/issues/149

Here's a test snippet that will hide the cart if there are no products added to cart (and on the cart and checkout pages):

```
add_filter( 'siteorigin_corp_display_mini_cart', function( $status ) {
	return ! is_cart() && ! is_checkout() && ! WC()->cart->is_empty();
} );
```