### PR TITLE
FlexSlider: Prevent Misalignment on Load in PB Full Width Row

### DIFF
--- a/js/jquery.theme.js
+++ b/js/jquery.theme.js
@@ -43,6 +43,11 @@
 					$( '.flexslider .slides img' ).show();
 				}
 			} );
+
+			// Prevent potential sizing issue if a FlexSlider is added inside of a PB full width row.
+			$( window ).one( 'panelsStretchRows', function() {
+				$( 'body:not(.siteorigin-panels-css-container) .siteorigin-panels-stretch .flexslider' ).flexslider().resize();
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
This PR prevents a misalignment on load when a FlexSlider is added inside of a non-Standard Page Builder Row Layout. The easiest way to test this PR is to use the Posts Slider Post Loop widget.

<img width="1915" alt="Screenshot 2021-10-18 at 20 06 53" src="https://user-images.githubusercontent.com/17275120/138370289-8f323738-006a-4e04-abcb-24c1192f5dec.png">