### PR TITLE
Return early if related posts categories empty

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -356,6 +356,7 @@ function siteorigin_corp_related_posts( $post_id ) {
 		echo do_shortcode( '[jetpack-related-posts]' );
 	} else { // The fallback loop.
 		$categories = get_the_category( $post_id );
+		if ( empty( $categories ) ) return;
 		$first_cat = $categories[0]->cat_ID;
 		$args=array(
 			'category__in' => array( $first_cat ),


### PR DESCRIPTION
Resolves:

![wp-job-listings-corp](https://user-images.githubusercontent.com/789159/147877636-8436cfab-8c88-47db-a9e2-c3013d4718e7.jpg)

