### PR TITLE
WC: Current Item Drop Down Sizing Fix

### DIFF
--- a/woocommerce/js/jquery.woocommerce.js
+++ b/woocommerce/js/jquery.woocommerce.js
@@ -39,7 +39,8 @@ jQuery( function( $ ) {
 					} )
 			);
 
-			widest = Math.max( c.find( '.current' ).html( $o.html() ).width(), widest);
+			c.find( '.current' ).html( $o.html() );
+			widest = Math.max( c.find( '.current' ).width(), widest);
 
 		} );
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-corp/issues/167

This PR resolves a sizing issue that can occur if the size of the current is calculated before the area has finished being added to the current item text.

It took quite a bit to get the underlying issue easily replicated as hard-refreshing didn't work for me. A new private browser window worked though.