### PR TITLE
Always Show Sticky Tag if Post Is Sticky

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -457,14 +457,7 @@ function siteorigin_corp_post_meta( $cats = true, $post_id = '', $echo = true ) 
 	/* translators: used between list items, there is a space after the comma */
 	$categories_list = get_the_category_list( esc_html__( ', ', 'siteorigin-corp' ) );
 
-	if (
-		is_sticky() &&
-		! is_paged() &&
-		(
-			is_home() ||
-			! is_main_query()
-		)
-	) {
+	if ( is_sticky() && ! is_paged() ) {
 		$output .= '<span class="featured-post">' . esc_html__( 'Sticky', 'siteorigin-corp' ) . '</span>';
 	}
 


### PR DESCRIPTION
Previously, only posts output on the frontend or in post loops would show the tag. Now it'll appear in search results and on archives.