### PR TITLE
Update WC Templates to 7.0.1

### DIFF
--- a/woocommerce/myaccount/form-edit-account.php
+++ b/woocommerce/myaccount/form-edit-account.php
@@ -11,8 +11,8 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
- * @version 3.5.0
+ * @package WooCommerce\Templates
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -64,7 +64,7 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 
 	<p>
 		<?php wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
-		<button type="submit" class="woocommerce-Button button" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'siteorigin-corp' ); ?>"><?php esc_html_e( 'Save changes', 'siteorigin-corp' ); ?></button>
+		<button type="submit" class="woocommerce-Button button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'siteorigin-corp' ); ?>"><?php esc_html_e( 'Save changes', 'siteorigin-corp' ); ?></button>
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 

--- a/woocommerce/product-searchform.php
+++ b/woocommerce/product-searchform.php
@@ -11,9 +11,8 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
- * @package WooCommerce/Templates
- * @version 3.3.0
+ * @package WooCommerce\Templates
+ * @version 7.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Updates two outdated templates.

```
siteorigin-corp/woocommerce/myaccount\form-edit-account.php version 3.5.0 is out of date. The core version is 7.0.1,
siteorigin-corp/woocommerce/product-searchform.php version 3.3.0 is out of date. The core version is 7.0.1,
```

No changes are required for the search form so just a version bump.