### PR TITLE
Account for theme review warning

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1819,7 +1819,7 @@ add_filter( 'siteorigin_page_settings_defaults', 'siteorigin_corp_setup_page_set
  */
 function siteorigin_corp_about_page_sections( $about ) {
 	$about['documentation_url'] = 'https://siteorigin.com/corp-documentation/';
-	$about['description']       = esc_html__( "A modern business theme from SiteOrigin. Corp is versatile and quick to customize. Fast loading and fully loaded with all the modern theme features you've come to expect and enjoy.", 'siteorigin-corp' );
+	$about['description']       = __( "A modern business theme from SiteOrigin. Corp is versatile and quick to customize. Fast loading and fully loaded with all the modern theme features you've come to expect and enjoy.", 'siteorigin-corp' );
 	$about['review']            = true;
 	$about['no_video']          = true;
 	$about['video_url']         = 'https://siteorigin.com/theme/corp/';


### PR DESCRIPTION
> WARNING: Found a translation function that is missing a text-domain in the file inc/settings.php. Function , with the arguments 'siteorigin-corp'.

> Line  1822: $about['description']       = esc_html__( 'A modern business theme from SiteOrigin. Corp is versatile and quick