### PR TITLE
Resolve Missing Text Domain

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -37,13 +37,10 @@ function siteorigin_corp_settings_init() {
 					'label'       => esc_html__( 'Retina Logo', 'siteorigin-corp' ),
 					'description' => esc_html__( 'A logo for use on high pixel density displays. Must be used in addition to a regular logo added in the Site Identity section and be exactly double the size.', 'siteorigin-corp' ),
 					'teaser' => array(
-						'text' => __(
-							sprintf(
-								'Enhance your SiteOrigin theme logo functionality with the %sLogo Booster Addon%s. Add an alternative logo on any page; upload a sticky logo to display on scroll.',
-								'<a href="https://siteorigin.com/downloads/premium/?featured_addon=theme/logo-booster" target="_blank" rel="noopener noreferrer">',
-								'</a>'
-							),
-							'siteorigin-corp'
+						'text' => sprintf(
+							__( 'Enhance your SiteOrigin theme logo functionality with the %sLogo Booster Addon%s. Add an alternative logo on any page; upload a sticky logo to display on scroll.', 'siteorigin-corp' ),
+							'<a href="https://siteorigin.com/downloads/premium/?featured_addon=theme/logo-booster" target="_blank" rel="noopener noreferrer">',
+							'</a>'
 						),
 					),
 				),


### PR DESCRIPTION
Resolves ` WARNING: Found a translation function that is missing a text-domain in the file inc/settings.php. Function __, with the arguments 'siteorigin-corp'. `